### PR TITLE
Improved appearance settings and cleaned up config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 # Build output
 dist/
+
+# User/Local config
+*.user
+*.ini
+*.local

--- a/contents/config/config.qml
+++ b/contents/config/config.qml
@@ -2,14 +2,14 @@ import QtQuick 2.0
 import org.kde.plasma.configuration 2.0
 
 ConfigModel {
-	ConfigCategory {
-		name: i18n("Appearance")
-		icon: "preferences-desktop-appearance"
-		source: "config/Appearance.qml"
-	}
-	ConfigCategory {
-		name: i18n("OpenLinkHub Integration")
-		icon: "network-connect"
-		source: "config/OpenLinkHub.qml"
-	}
+    ConfigCategory {
+        name: i18n("Appearance")
+        icon: "preferences-desktop-color"
+        source: "config/Appearance.qml"
+    }
+    ConfigCategory {
+        name: i18n("OpenLinkHub Integration")
+        icon: "network-connect"
+        source: "config/OpenLinkHub.qml"
+    }
 }

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -9,11 +9,24 @@
     <entry name="hiddenDevices" type="String">
       <default></default>
     </entry>
-    <entry name="enableOpenLinkHubIntegration" type="bool">
-      <default>true</default>
+  </group>
+
+  <group name="Appearance">
+    <entry name="fontFamily" type="String">
+      <label>Widget font family</label>
+      <default></default>
     </entry>
-    <entry name="openLinkHubApiPort" type="Int">
-      <default>27003</default>
+    <entry name="fontBold" type="Bool">
+      <label>Shall font be bold?</label>
+      <default>false</default>
+    </entry>
+    <entry name="fontWeight" type="Int">
+      <label>Thickness of bold</label>
+      <default>500</default>
+    </entry>
+    <entry name="fontItalic" type="Bool">
+      <label>Shall font be itallic?</label>
+      <default>false</default>
     </entry>
     <entry name="useCustomFontSize" type="bool">
       <default>false</default>
@@ -26,6 +39,15 @@
     </entry>
     <entry name="customIconSize" type="Int">
       <default>22</default>
+    </entry>
+  </group>
+
+  <group name="OpenLinkHub">
+    <entry name="enableOpenLinkHubIntegration" type="bool">
+      <default>true</default>
+    </entry>
+    <entry name="openLinkHubApiPort" type="Int">
+      <default>27003</default>
     </entry>
   </group>
 </kcfg>

--- a/contents/ui/config/Appearance.qml
+++ b/contents/ui/config/Appearance.qml
@@ -1,49 +1,193 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.5 as QQC2
-import QtQuick.Layouts 1.1
+import QtQuick.Layouts 1.1 as QQL
 import org.kde.kirigami 2.4 as Kirigami
 import org.kde.kcmutils as KCMUtils
 
 KCMUtils.SimpleKCM {
-	id: root
+    id: root
 
-	property alias cfg_useCustomFontSize: useCustomFontSize.checked
-	property alias cfg_useCustomIconSize: useCustomIconSize.checked
-	property alias cfg_customFontSize: customFontSize.value
-	property alias cfg_customIconSize: customIconSize.value
+    property alias cfg_fontFamily: page.cfg_fontFamily
+    property alias cfg_fontBold: boldCheckBox.checked
+    property alias cfg_fontWeight: fontWeight.value
+    property alias cfg_fontItalic: italicCheckBox.checked
+    property alias cfg_useCustomFontSize: useCustomFontSize.checked
+    property alias cfg_customFontSize: customFontSize.value
+    property alias cfg_useCustomIconSize: useCustomIconSize.checked
+    property alias cfg_customIconSize: customIconSize.value
 
-	Kirigami.FormLayout {
-		id: page
+    Kirigami.FormLayout {
+        id: page
 
-		anchors.left: parent.left
-		anchors.right: parent.right
+        // anchors.left: parent.left
+        // anchors.right: parent.right
 
-		QQC2.CheckBox {
-			id: useCustomFontSize
-			Kirigami.FormData.label: i18n("Custom Font Size: ")
-			text: i18n("Enabled")
-		}
+        // Bound to SimpleKCM cfg_fontFamily - "" = "System default"
+        property string cfg_fontFamily
+        // Shared width for all Spinboxes
+        readonly property int boxWidth: Kirigami.Units.gridUnit * 3
 
-		QQC2.SpinBox {
-			id: customFontSize
-			Kirigami.FormData.label: i18n("Size (px): ")
-			from: 4
-			to: 72
-			enabled: useCustomFontSize.checked
-		}
+        // Fetches fonts
+        ListModel {
+            id: fontsModel
 
-		QQC2.CheckBox {
-			id: useCustomIconSize
-			Kirigami.FormData.label: i18n("Custom Device Icon Size: ")
-			text: i18n("Enabled")
-		}
+            Component.onCompleted: {
+                const systemFont = Kirigami.Theme.defaultFont.family;
+                const fonts = Qt.fontFamilies();
+                const arr = [
+                    {
+                        // Empty value keeps sys default font
+                        text: i18n("System Default (%1)", systemFont),
+                        value: ""
+                    }
+                ];
 
-		QQC2.SpinBox {
-			id: customIconSize
-			Kirigami.FormData.label: i18n("Size (px): ")
-			from: 8
-			to: 128
-			enabled: useCustomIconSize.checked
-		}
-	}
+                for (let i = 0, fontCount = fonts.length; i < fontCount; ++i) {
+                    arr.push({
+                        text: fonts[i],
+                        value: fonts[i]
+                    });
+                }
+
+                append(arr);
+            }
+        }
+
+        Item {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Applet Tray Settings")
+        }
+
+        QQL.RowLayout {
+            QQL.Layout.fillWidth: true
+            Kirigami.FormData.label: i18n("Font family:")
+
+            QQC2.ComboBox {
+                id: fontFamily
+                model: fontsModel
+                textRole: "text"
+                valueRole: "value"
+                currentValue: page.cfg_fontFamily
+                QQL.Layout.preferredWidth: page.boxWidth * 6
+
+                // Does not autosync -> updat explicitly on change
+                onCurrentValueChanged: {
+                    page.cfg_fontFamily = currentValue;
+                }
+            }
+        }
+
+        QQL.RowLayout {
+            Kirigami.FormData.label: i18n("Style")
+            QQL.Layout.fillWidth: true
+
+            // Explicit grid to keep elements properly aligned
+            // | checkbox | spinbox | -- | spacer | checkbox | italic | -- |
+            // | checkbox | spinbox | px | spacer | checkbox | spacer | px |
+            QQL.GridLayout {
+                columns: 7
+                columnSpacing: Kirigami.Units.smallSpacing
+                rowSpacing: Kirigami.Units.smallSpacing
+
+                QQC2.CheckBox {
+                    id: boldCheckBox
+                    text: i18n("Bold")
+                    QQL.Layout.column: 0
+                    QQL.Layout.row: 0
+                }
+
+                QQC2.SpinBox {
+                    // CSS / Qt scale: 100 - 1000
+                    id: fontWeight
+                    enabled: boldCheckBox.checked
+                    from: 100
+                    to: 1000
+                    stepSize: 100
+                    QQL.Layout.column: 1
+                    QQL.Layout.row: 0
+                    QQL.Layout.preferredWidth: page.boxWidth
+                }
+
+                Item {
+                    QQL.Layout.column: 2
+                    QQL.Layout.row: 0
+                }
+
+                Item {
+                    QQL.Layout.column: 3
+                    QQL.Layout.row: 0
+                    // Visual spacing in between elements
+                    width: 5
+                }
+
+                QQC2.CheckBox {
+                    id: italicCheckBox
+                    text: i18n("Italic")
+                    QQL.Layout.column: 4
+                    QQL.Layout.row: 0
+                }
+
+                Item {
+                    QQL.Layout.column: 5
+                    QQL.Layout.row: 0
+                }
+
+                QQC2.CheckBox {
+                    id: useCustomFontSize
+                    text: i18n("Font size")
+                    QQL.Layout.column: 0
+                    QQL.Layout.row: 1
+                }
+
+                QQC2.SpinBox {
+                    id: customFontSize
+                    enabled: useCustomFontSize.checked
+                    from: 4
+                    to: 72
+                    QQL.Layout.column: 1
+                    QQL.Layout.row: 1
+                    QQL.Layout.preferredWidth: page.boxWidth
+                }
+
+                QQC2.Label {
+                    text: i18n("px")
+                    opacity: 0.7
+                    verticalAlignment: Text.AlignVCenter
+                    QQL.Layout.column: 2
+                    QQL.Layout.row: 1
+                }
+
+                Item {
+                    QQL.Layout.column: 3
+                    QQL.Layout.row: 1
+                    width: 5
+                }
+
+                QQC2.CheckBox {
+                    id: useCustomIconSize
+                    text: i18n("Icon size")
+                    QQL.Layout.column: 4
+                    QQL.Layout.row: 1
+                }
+
+                QQC2.SpinBox {
+                    id: customIconSize
+                    enabled: useCustomIconSize.checked
+                    from: 8
+                    to: 128
+                    QQL.Layout.column: 5
+                    QQL.Layout.row: 1
+                    QQL.Layout.preferredWidth: page.boxWidth
+                }
+
+                QQC2.Label {
+                    text: i18n("px")
+                    opacity: 0.7
+                    verticalAlignment: Text.AlignVCenter
+                    QQL.Layout.column: 6
+                    QQL.Layout.row: 1
+                }
+            }
+        }
+    }
 }

--- a/contents/ui/config/OpenLinkHub.qml
+++ b/contents/ui/config/OpenLinkHub.qml
@@ -4,29 +4,28 @@ import org.kde.kirigami 2.4 as Kirigami
 import org.kde.kcmutils as KCMUtils
 
 KCMUtils.SimpleKCM {
-	id: root
+    id: root
 
-	property alias cfg_enableOpenLinkHubIntegration: enableOpenLinkHubIntegration.checked
-	property alias cfg_openLinkHubApiPort: openLinkHubApiPort.value
+    property alias cfg_enableOpenLinkHubIntegration: enableOpenLinkHubIntegration.checked
+    property alias cfg_openLinkHubApiPort: openLinkHubApiPort.value
 
-	Kirigami.FormLayout {
-		id: page
+    Kirigami.FormLayout {
+        id: page
 
         anchors.left: parent.left
         anchors.right: parent.right
 
-		QQC2.CheckBox {
-			id: enableOpenLinkHubIntegration
-			Kirigami.FormData.label: i18n("Enable OpenLinkHub Integration: ")
-			text: i18n("Enabled")
-		}
-		
-		QQC2.SpinBox {
-			id: openLinkHubApiPort
-			Kirigami.FormData.label: i18n("OpenLinkHub Port: ")
-			to: 65535
-			enabled: enableOpenLinkHubIntegration.checked
-		}
+        QQC2.CheckBox {
+            id: enableOpenLinkHubIntegration
+            Kirigami.FormData.label: i18n("Enable OpenLinkHub Integration: ")
+            text: i18n("Enabled")
+        }
 
-	}
+        QQC2.SpinBox {
+            id: openLinkHubApiPort
+            Kirigami.FormData.label: i18n("OpenLinkHub Port: ")
+            to: 65535
+            enabled: enableOpenLinkHubIntegration.checked
+        }
+    }
 }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -8,511 +8,517 @@ import org.kde.plasma.plasma5support 2.0 as P5Support
 import "providers"
 
 PlasmoidItem {
-	id: root
-
-	// ═══════════════════════════════════════════════════════════════════════
-	// PROVIDERS
-	// ═══════════════════════════════════════════════════════════════════════
-
-	UPowerProvider {
-		id: upowerProvider
-	}
-
-	CompanionProvider {
-		id: companionProvider
-	}
-
-	OpenLinkHubProvider {
-		id: openLinkHubProvider
-	}
-
-	OpenRazerProvider {
-		id: openRazerProvider
-	}
-
-	// List of providers (in priority order)
-	property var providers: [upowerProvider, companionProvider, openLinkHubProvider, openRazerProvider]
-
-	// ═══════════════════════════════════════════════════════════════════════
-	// DEVICE STATE
-	// ═══════════════════════════════════════════════════════════════════════
-
-	// Merged devices from all providers
-	property var allDevices: mergeDevices(providers.map(p => p.devices))
-	property var hiddenDevices: []
-
-	property int visibleDeviceCount: {
-		var count = 0
-		for (var i = 0; i < allDevices.length; i++) {
-			if (hiddenDevices.indexOf(allDevices[i].serial) === -1) {
-				count++
-			}
-		}
-		return count
-	}
-
-	property bool hasVisibleDevices: visibleDeviceCount > 0
-	property bool hasAnyDevices: allDevices.length > 0
-	property bool allDevicesHidden: hasAnyDevices && !hasVisibleDevices
-
-	// Tray items: flattened list for compact representation
-	// For multi-battery devices, only shows batteries with showInTray=true
-	property var trayItems: buildTrayItems(allDevices, hiddenDevices)
-
-	function buildTrayItems(devices, hidden) {
-		var items = []
-		for (var i = 0; i < devices.length; i++) {
-			var device = devices[i]
-			if (hidden.indexOf(device.serial) !== -1) continue
-
-			// Multi-battery device (e.g., AirPods)
-			if (device.batteries && device.batteries.length > 1) {
-				for (var j = 0; j < device.batteries.length; j++) {
-					var bat = device.batteries[j]
-
-					// Skip batteries marked as not for tray (e.g., Case)
-					if (bat.showInTray === false) continue
-
-					items.push({
-						icon: device.icon,
-						percentage: bat.percentage,
-						label: bat.label,
-						deviceSerial: device.serial
-					})
-				}
-			} else {
-				// Single battery device
-				items.push({
-					icon: device.icon,
-					percentage: device.percentage,
-					label: null,
-					deviceSerial: device.serial
-				})
-			}
-		}
-		return items
-	}
-
-	// ═══════════════════════════════════════════════════════════════════════
-	// DEVICE MERGING
-	// ═══════════════════════════════════════════════════════════════════════
-
-	// Merge devices from multiple providers, avoiding duplicates
-	// deviceProviders: array of device arrays in priority order (first = highest priority)
-	function mergeDevices(deviceProviders) {
-		var merged = []
-		var seenIds = {}
-
-		for (var providerIdx = 0; providerIdx < deviceProviders.length; providerIdx++) {
-			var devices = deviceProviders[providerIdx]
-
-			for (var i = 0; i < devices.length; i++) {
-				var device = devices[i]
-				var id = device.serial || device.objectPath || ""
-
-				if (id && !seenIds[id]) {
-					merged.push(device)
-					seenIds[id] = true
-				}
-			}
-		}
-
-		// Sort by name
-		merged.sort((a, b) => {
-			var nameA = a.name || ""
-			var nameB = b.name || ""
-			return nameA.localeCompare(nameB)
-		})
-
-		return merged
-	}
-
-	// ═══════════════════════════════════════════════════════════════════════
-	// WIDGET CONFIGURATION
-	// ═══════════════════════════════════════════════════════════════════════
-
-	preferredRepresentation: compactRepresentation
-
-	// i18n: %1 is the version number.
-	toolTipMainText: i18n("BatteryWatch v%1", Plasmoid.metaData.version)
-	toolTipSubText: {
-		if (allDevices.length === 0) {
-			return i18n("No connected devices")
-		}
-
-		var lines = []
-		for (var i = 0; i < allDevices.length; i++) {
-			var device = allDevices[i]
-			if (hiddenDevices.indexOf(device.serial) !== -1) continue
-
-			var line = device.name
-
-			// Multi-battery display
-			if (device.batteries && device.batteries.length > 1) {
-				var parts = []
-				for (var j = 0; j < device.batteries.length; j++) {
-					var bat = device.batteries[j]
-					// i18n: %1 can be the device name or, in the case of multiple batteries, the battery label, 
-					// or simply the word, ‘Battery’. %2 is the charge percentage value.
-					parts.push(i18n("%1: %2%", bat.label || "Battery", bat.percentage))
-				}
-				// i18n: Used when there are multiple batteries in a device. 
-				// %1 is the device name. 
-				// %2 is the delimited list of the device's batteries and their charge percentages.
-				line = i18n("%1 - %2", line,
-					// i18n: The delimiter when listing multiple batteries in the same device.
-					parts.join(i18n(", ")))
-			} else {
-				line = i18n("%1: %2%", line, device.percentage)
-			}
-
-			lines.push(line)
-		}
-
-		return lines.length > 0 ? lines.join("\n") : i18n("All devices hidden")
-	}
-
-	Plasmoid.status: {
-		if (Plasmoid.userConfiguring) {
-			return PlasmaCore.Types.ActiveStatus
-		}
-		if (Plasmoid.containment && Plasmoid.containment.corona && Plasmoid.containment.corona.editMode) {
-			return PlasmaCore.Types.ActiveStatus
-		}
-		return hasAnyDevices ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
-	}
-
-	// ═══════════════════════════════════════════════════════════════════════
-	// HIDDEN DEVICES PERSISTENCE
-	// ═══════════════════════════════════════════════════════════════════════
-
-	Component.onCompleted: {
-		loadHiddenDevices()
-	}
-
-	function loadHiddenDevices() {
-		var saved = Plasmoid.configuration.hiddenDevices
-		if (saved) {
-			hiddenDevices = saved.split(",").filter(s => s.length > 0)
-		} else {
-			hiddenDevices = []
-		}
-	}
-
-	function saveHiddenDevices() {
-		Plasmoid.configuration.hiddenDevices = hiddenDevices.join(i18n(", "))
-	}
-
-	function toggleDeviceVisibility(serial) {
-		var index = hiddenDevices.indexOf(serial)
-		if (index === -1) {
-			hiddenDevices.push(serial)
-		} else {
-			hiddenDevices.splice(index, 1)
-		}
-		hiddenDevices = hiddenDevices.slice()
-		saveHiddenDevices()
-	}
-
-	// ═══════════════════════════════════════════════════════════════════════
-	// DEVICE ACTIONS
-	// ═══════════════════════════════════════════════════════════════════════
-
-	function refreshDevices() {
-		for (var i = 0; i < providers.length; i++) {
-			providers[i].refresh()
-		}
-	}
-
-	P5Support.DataSource {
-		id: bluetoothCtlSource
-		engine: "executable"
-		connectedSources: []
-		interval: 0
-
-		onNewData: (sourceName, data) => {
-			disconnectSource(sourceName)
-			Qt.callLater(refreshDevices)
-		}
-	}
-
-	function disconnectBluetoothDevice(bluetoothAddress) {
-		if (bluetoothAddress) {
-			bluetoothCtlSource.connectSource("bluetoothctl disconnect " + bluetoothAddress)
-		}
-	}
-
-	// ═══════════════════════════════════════════════════════════════════════
-	// COMPACT REPRESENTATION (System Tray)
-	// ═══════════════════════════════════════════════════════════════════════
-
-	compactRepresentation: Item {
-		property bool inEditMode: {
-			if (Plasmoid.userConfiguring) return true
-			if (Plasmoid.containment && Plasmoid.containment.corona && Plasmoid.containment.corona.editMode) return true
-			return false
-		}
-
-		property bool shouldShow: root.hasVisibleDevices || root.allDevicesHidden || inEditMode
-
-		Layout.minimumWidth: shouldShow ? -1 : 0
-		Layout.minimumHeight: shouldShow ? -1 : 0
-		Layout.preferredWidth: shouldShow ? (root.hasVisibleDevices ? mainLayout.implicitWidth : placeholderIcon.width) : 0
-		Layout.preferredHeight: shouldShow ? (root.hasVisibleDevices ? mainLayout.implicitHeight : placeholderIcon.height) : 0
-		Layout.maximumWidth: shouldShow ? -1 : 0
-		Layout.maximumHeight: shouldShow ? -1 : 0
-
-		Kirigami.Icon {
-			id: placeholderIcon
-			anchors.centerIn: parent
-			source: root.allDevicesHidden ? Qt.resolvedUrl("../icons/hidden-devices.png") : Qt.resolvedUrl("../icons/battery-monitor.png")
-			width: Kirigami.Units.iconSizes.smallMedium
-			height: Kirigami.Units.iconSizes.smallMedium
-			visible: !root.hasVisibleDevices && (inEditMode || root.allDevicesHidden)
-		}
-
-		GridLayout {
-			id: mainLayout
-			anchors.centerIn: parent
-			rowSpacing: Kirigami.Units.smallSpacing
-			columnSpacing: Kirigami.Units.smallSpacing
-			flow: Plasmoid.formFactor === PlasmaCore.Types.Vertical ? GridLayout.TopToBottom : GridLayout.LeftToRight
-			visible: root.hasVisibleDevices
-
-			Repeater {
-				model: root.trayItems
-
-				GridLayout {
-					rowSpacing: 2
-					columnSpacing: 2
-					flow: mainLayout.flow
-
-					Kirigami.Icon {
-						source: modelData.icon
-						Layout.preferredWidth: Plasmoid.configuration.useCustomIconSize ? Plasmoid.configuration.customIconSize : Kirigami.Units.iconSizes.smallMedium
-						Layout.preferredHeight: Plasmoid.configuration.useCustomIconSize ? Plasmoid.configuration.customIconSize : Kirigami.Units.iconSizes.smallMedium
-						Layout.alignment: Qt.AlignCenter
-					}
-
-					PlasmaComponents.Label {
-						// i18n: %1 is the charge percentage value.
-						text: i18n("%1%", modelData.percentage)
-						font.pixelSize: Plasmoid.configuration.useCustomFontSize ? Plasmoid.configuration.customFontSize : Kirigami.Theme.smallFont.pixelSize
-						Layout.alignment: Qt.AlignCenter
-						horizontalAlignment: Text.AlignHCenter
-						verticalAlignment: Text.AlignVCenter
-					}
-				}
-			}
-		}
-
-		MouseArea {
-			anchors.fill: parent
-			onClicked: root.expanded = !root.expanded
-		}
-	}
-
-	// ═══════════════════════════════════════════════════════════════════════
-	// FULL REPRESENTATION (Popup)
-	// ═══════════════════════════════════════════════════════════════════════
-
-	fullRepresentation: Item {
-		Layout.minimumWidth: Kirigami.Units.gridUnit * 25
-		Layout.preferredWidth: Kirigami.Units.gridUnit * 30
-		Layout.minimumHeight: Kirigami.Units.gridUnit * 8
-		Layout.preferredHeight: {
-			var baseHeight = Kirigami.Units.gridUnit * 5
-			var deviceHeight = root.allDevices.length * Kirigami.Units.gridUnit * 4
-			var totalHeight = baseHeight + deviceHeight
-			var maxHeight = Kirigami.Units.gridUnit * 17
-			return Math.min(totalHeight, maxHeight)
-		}
-		Layout.maximumHeight: Kirigami.Units.gridUnit * 35
-
-		ColumnLayout {
-			anchors.fill: parent
-			anchors.margins: Kirigami.Units.largeSpacing
-			spacing: Kirigami.Units.smallSpacing
-
-			RowLayout {
-				Layout.fillWidth: true
-				spacing: Kirigami.Units.smallSpacing
-
-				PlasmaComponents.Label {
-					text: i18n("Device Battery Levels")
-					font.bold: true
-					font.pixelSize: Kirigami.Theme.defaultFont.pixelSize * 1.2
-					Layout.fillWidth: true
-				}
-
-				PlasmaComponents.ToolButton {
-					icon.name: "view-refresh"
-					text: i18n("Refresh")
-					display: PlasmaComponents.AbstractButton.IconOnly
-
-					PlasmaComponents.ToolTip {
-						text: i18n("Refresh devices")
-					}
-
-					onClicked: {
-						refreshDevices()
-					}
-				}
-			}
-
-			PlasmaComponents.ScrollView {
-				Layout.fillWidth: true
-				Layout.fillHeight: true
-
-				clip: true
-
-				PlasmaComponents.ScrollBar.horizontal.policy: PlasmaComponents.ScrollBar.AlwaysOff
-
-				ColumnLayout {
-					width: parent.parent.width - Kirigami.Units.largeSpacing
-					spacing: 0
-
-					Repeater {
-						model: root.allDevices
-
-						ColumnLayout {
-							Layout.fillWidth: true
-							spacing: 0
-
-							// Store reference to device for nested components
-							property var device: modelData
-							property bool hasMultipleBatteries: device.batteries && device.batteries.length > 1
-
-							Item {
-								Layout.fillWidth: true
-								Layout.preferredHeight: Kirigami.Units.gridUnit * 4
-								Layout.topMargin: Kirigami.Units.smallSpacing
-								Layout.bottomMargin: Kirigami.Units.smallSpacing
-
-								RowLayout {
-									anchors.fill: parent
-									spacing: Kirigami.Units.smallSpacing
-
-									Kirigami.Icon {
-										source: device.icon
-										Layout.preferredWidth: Kirigami.Units.iconSizes.medium
-										Layout.preferredHeight: Kirigami.Units.iconSizes.medium
-										Layout.alignment: Qt.AlignVCenter
-									}
-
-									ColumnLayout {
-										Layout.fillWidth: true
-										Layout.alignment: Qt.AlignVCenter
-										spacing: 2
-
-										PlasmaComponents.Label {
-											text: device.name || i18n("Unknown Device")
-											font.bold: true
-											Layout.fillWidth: true
-											elide: Text.ElideRight
-										}
-
-										PlasmaComponents.Label {
-											text: device.serial
-											font.pixelSize: Kirigami.Theme.smallFont.pixelSize
-											color: Kirigami.Theme.disabledTextColor
-											Layout.fillWidth: true
-											elide: Text.ElideRight
-										}
-
-										// Multi-battery row (shown under MAC address)
-										RowLayout {
-											visible: hasMultipleBatteries
-											Layout.fillWidth: true
-											spacing: Kirigami.Units.largeSpacing
-
-											Repeater {
-												model: hasMultipleBatteries ? device.batteries : []
-
-												PlasmaComponents.Label {
-													text: {
-														var bat = modelData
-														var label = bat.label || i18n("Battery")
-														var charging = bat.charging ? " ⚡" : ""
-														// i18n: %1 is the battery label or simply the word, ‘Battery’. %2 is the charge percentage value. 
-														// %3 is a Unicode lightning symbol displayed when the device is charging.
-														return i18n("%1: %2%%3", label, bat.percentage, charging)
-													}
-													font.pixelSize: Kirigami.Theme.smallFont.pixelSize
-												}
-											}
-										}
-									}
-
-									RowLayout {
-										Layout.alignment: Qt.AlignVCenter
-
-										PlasmaComponents.ToolButton {
-											visible: device.connectionType === 2 && device.bluetoothAddress
-											icon.name: "network-disconnect"
-											text: i18n("Disconnect")
-											display: PlasmaComponents.AbstractButton.IconOnly
-											onClicked: disconnectBluetoothDevice(device.bluetoothAddress)
-
-											PlasmaComponents.ToolTip {
-												text: i18n("Disconnect device")
-											}
-
-											MouseArea {
-												anchors.fill: parent
-												hoverEnabled: true
-												cursorShape: Qt.PointingHandCursor
-												onPressed: mouse.accepted = false
-											}
-										}
-
-										PlasmaComponents.ToolButton {
-											icon.name: root.hiddenDevices.indexOf(device.serial) === -1 ? "view-visible" : "view-hidden"
-											text: root.hiddenDevices.indexOf(device.serial) === -1 ? i18n("Hide") : i18n("Show")
-											display: PlasmaComponents.AbstractButton.IconOnly
-											onClicked: toggleDeviceVisibility(device.serial)
-
-											PlasmaComponents.ToolTip {
-												text: root.hiddenDevices.indexOf(device.serial) === -1 ? i18n("Hide from tray") : i18n("Show in tray")
-											}
-
-											MouseArea {
-												anchors.fill: parent
-												hoverEnabled: true
-												cursorShape: Qt.PointingHandCursor
-												onPressed: mouse.accepted = false
-											}
-										}
-
-										// Single battery: show percentage
-										PlasmaComponents.Label {
-											visible: !hasMultipleBatteries
-											text: i18n("%1%", device.percentage)
-											font.bold: true
-											Layout.minimumWidth: Kirigami.Units.gridUnit * 2
-											horizontalAlignment: Text.AlignRight
-										}
-									}
-								}
-							}
-
-							Kirigami.Separator {
-								Layout.fillWidth: true
-								visible: index < root.allDevices.length - 1
-							}
-						}
-					}
-
-					PlasmaComponents.Label {
-						visible: root.allDevices.length === 0
-						text: i18n("No connected devices with battery info found")
-						Layout.fillWidth: true
-						Layout.topMargin: Kirigami.Units.largeSpacing
-						horizontalAlignment: Text.AlignHCenter
-						color: Kirigami.Theme.disabledTextColor
-					}
-				}
-			}
-		}
-	}
+    id: root
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // PROVIDERS
+    // ═══════════════════════════════════════════════════════════════════════
+
+    UPowerProvider {
+        id: upowerProvider
+    }
+
+    CompanionProvider {
+        id: companionProvider
+    }
+
+    OpenLinkHubProvider {
+        id: openLinkHubProvider
+    }
+
+    OpenRazerProvider {
+        id: openRazerProvider
+    }
+
+    // List of providers (in priority order)
+    property var providers: [upowerProvider, companionProvider, openLinkHubProvider, openRazerProvider]
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // DEVICE STATE
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // Merged devices from all providers
+    property var allDevices: mergeDevices(providers.map(p => p.devices))
+    property var hiddenDevices: []
+
+    property int visibleDeviceCount: {
+        var count = 0;
+        for (var i = 0; i < allDevices.length; i++) {
+            if (hiddenDevices.indexOf(allDevices[i].serial) === -1) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    property bool hasVisibleDevices: visibleDeviceCount > 0
+    property bool hasAnyDevices: allDevices.length > 0
+    property bool allDevicesHidden: hasAnyDevices && !hasVisibleDevices
+
+    // Tray items: flattened list for compact representation
+    // For multi-battery devices, only shows batteries with showInTray=true
+    property var trayItems: buildTrayItems(allDevices, hiddenDevices)
+
+    function buildTrayItems(devices, hidden) {
+        var items = [];
+        for (var i = 0; i < devices.length; i++) {
+            var device = devices[i];
+            if (hidden.indexOf(device.serial) !== -1)
+                continue;
+
+            // Multi-battery device (e.g., AirPods)
+            if (device.batteries && device.batteries.length > 1) {
+                for (var j = 0; j < device.batteries.length; j++) {
+                    var bat = device.batteries[j];
+
+                    // Skip batteries marked as not for tray (e.g., Case)
+                    if (bat.showInTray === false)
+                        continue;
+                    items.push({
+                        icon: device.icon,
+                        percentage: bat.percentage,
+                        label: bat.label,
+                        deviceSerial: device.serial
+                    });
+                }
+            } else {
+                // Single battery device
+                items.push({
+                    icon: device.icon,
+                    percentage: device.percentage,
+                    label: null,
+                    deviceSerial: device.serial
+                });
+            }
+        }
+        return items;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // DEVICE MERGING
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // Merge devices from multiple providers, avoiding duplicates
+    // deviceProviders: array of device arrays in priority order (first = highest priority)
+    function mergeDevices(deviceProviders) {
+        var merged = [];
+        var seenIds = {};
+
+        for (var providerIdx = 0; providerIdx < deviceProviders.length; providerIdx++) {
+            var devices = deviceProviders[providerIdx];
+
+            for (var i = 0; i < devices.length; i++) {
+                var device = devices[i];
+                var id = device.serial || device.objectPath || "";
+
+                if (id && !seenIds[id]) {
+                    merged.push(device);
+                    seenIds[id] = true;
+                }
+            }
+        }
+
+        // Sort by name
+        merged.sort((a, b) => {
+            var nameA = a.name || "";
+            var nameB = b.name || "";
+            return nameA.localeCompare(nameB);
+        });
+
+        return merged;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // WIDGET CONFIGURATION
+    // ═══════════════════════════════════════════════════════════════════════
+
+    preferredRepresentation: compactRepresentation
+
+    // i18n: %1 is the version number.
+    toolTipMainText: i18n("BatteryWatch v%1", Plasmoid.metaData.version)
+    toolTipSubText: {
+        if (allDevices.length === 0) {
+            return i18n("No connected devices");
+        }
+
+        var lines = [];
+        for (var i = 0; i < allDevices.length; i++) {
+            var device = allDevices[i];
+            if (hiddenDevices.indexOf(device.serial) !== -1)
+                continue;
+            var line = device.name;
+
+            // Multi-battery display
+            if (device.batteries && device.batteries.length > 1) {
+                var parts = [];
+                for (var j = 0; j < device.batteries.length; j++) {
+                    var bat = device.batteries[j];
+                    // i18n: %1 can be the device name or, in the case of multiple batteries, the battery label,
+                    // or simply the word, ‘Battery’. %2 is the charge percentage value.
+                    parts.push(i18n("%1: %2%", bat.label || "Battery", bat.percentage));
+                }
+                // i18n: Used when there are multiple batteries in a device.
+                // %1 is the device name.
+                // %2 is the delimited list of the device's batteries and their charge percentages.
+                line = i18n("%1 - %2", line,
+                // i18n: The delimiter when listing multiple batteries in the same device.
+                parts.join(i18n(", ")));
+            } else {
+                line = i18n("%1: %2%", line, device.percentage);
+            }
+
+            lines.push(line);
+        }
+
+        return lines.length > 0 ? lines.join("\n") : i18n("All devices hidden");
+    }
+
+    Plasmoid.status: {
+        if (Plasmoid.userConfiguring) {
+            return PlasmaCore.Types.ActiveStatus;
+        }
+        if (Plasmoid.containment && Plasmoid.containment.corona && Plasmoid.containment.corona.editMode) {
+            return PlasmaCore.Types.ActiveStatus;
+        }
+        return hasAnyDevices ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // HIDDEN DEVICES PERSISTENCE
+    // ═══════════════════════════════════════════════════════════════════════
+
+    Component.onCompleted: {
+        loadHiddenDevices();
+    }
+
+    function loadHiddenDevices() {
+        var saved = Plasmoid.configuration.hiddenDevices;
+        if (saved) {
+            hiddenDevices = saved.split(",").filter(s => s.length > 0);
+        } else {
+            hiddenDevices = [];
+        }
+    }
+
+    function saveHiddenDevices() {
+        Plasmoid.configuration.hiddenDevices = hiddenDevices.join(i18n(", "));
+    }
+
+    function toggleDeviceVisibility(serial) {
+        var index = hiddenDevices.indexOf(serial);
+        if (index === -1) {
+            hiddenDevices.push(serial);
+        } else {
+            hiddenDevices.splice(index, 1);
+        }
+        hiddenDevices = hiddenDevices.slice();
+        saveHiddenDevices();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // DEVICE ACTIONS
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function refreshDevices() {
+        for (var i = 0; i < providers.length; i++) {
+            providers[i].refresh();
+        }
+    }
+
+    P5Support.DataSource {
+        id: bluetoothCtlSource
+        engine: "executable"
+        connectedSources: []
+        interval: 0
+
+        onNewData: (sourceName, data) => {
+            disconnectSource(sourceName);
+            Qt.callLater(refreshDevices);
+        }
+    }
+
+    function disconnectBluetoothDevice(bluetoothAddress) {
+        if (bluetoothAddress) {
+            bluetoothCtlSource.connectSource("bluetoothctl disconnect " + bluetoothAddress);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // COMPACT REPRESENTATION (System Tray)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    compactRepresentation: Item {
+        property bool inEditMode: {
+            if (Plasmoid.userConfiguring)
+                return true;
+            if (Plasmoid.containment && Plasmoid.containment.corona && Plasmoid.containment.corona.editMode)
+                return true;
+            return false;
+        }
+
+        property bool shouldShow: root.hasVisibleDevices || root.allDevicesHidden || inEditMode
+
+        Layout.minimumWidth: shouldShow ? -1 : 0
+        Layout.minimumHeight: shouldShow ? -1 : 0
+        Layout.preferredWidth: shouldShow ? (root.hasVisibleDevices ? mainLayout.implicitWidth : placeholderIcon.width) : 0
+        Layout.preferredHeight: shouldShow ? (root.hasVisibleDevices ? mainLayout.implicitHeight : placeholderIcon.height) : 0
+        Layout.maximumWidth: shouldShow ? -1 : 0
+        Layout.maximumHeight: shouldShow ? -1 : 0
+
+        Kirigami.Icon {
+            id: placeholderIcon
+            anchors.centerIn: parent
+            source: root.allDevicesHidden ? Qt.resolvedUrl("../icons/hidden-devices.png") : Qt.resolvedUrl("../icons/battery-monitor.png")
+            width: Kirigami.Units.iconSizes.smallMedium
+            height: Kirigami.Units.iconSizes.smallMedium
+            visible: !root.hasVisibleDevices && (inEditMode || root.allDevicesHidden)
+        }
+
+        GridLayout {
+            id: mainLayout
+            anchors.centerIn: parent
+            rowSpacing: Kirigami.Units.smallSpacing
+            columnSpacing: Kirigami.Units.smallSpacing
+            flow: Plasmoid.formFactor === PlasmaCore.Types.Vertical ? GridLayout.TopToBottom : GridLayout.LeftToRight
+            visible: root.hasVisibleDevices
+
+            Repeater {
+                model: root.trayItems
+
+                GridLayout {
+                    rowSpacing: 2
+                    columnSpacing: 2
+                    flow: mainLayout.flow
+
+                    Kirigami.Icon {
+                        source: modelData.icon
+                        Layout.preferredWidth: Plasmoid.configuration.useCustomIconSize ? Plasmoid.configuration.customIconSize : Kirigami.Units.iconSizes.smallMedium
+                        Layout.preferredHeight: Plasmoid.configuration.useCustomIconSize ? Plasmoid.configuration.customIconSize : Kirigami.Units.iconSizes.smallMedium
+                        Layout.alignment: Qt.AlignCenter
+                    }
+
+                    PlasmaComponents.Label {
+                        // i18n: %1 is the charge percentage value.
+                        text: i18n("%1%", modelData.percentage)
+                        font.family: Plasmoid.configuration.fontFamily !== "" ? Plasmoid.configuration.fontFamily : Kirigami.Theme.smallFont.family
+                        font.weight: Plasmoid.configuration.fontBold ? Plasmoid.configuration.fontWeight : Font.Normal
+                        font.italic: Plasmoid.configuration.fontItalic
+                        font.pixelSize: Plasmoid.configuration.useCustomFontSize ? Plasmoid.configuration.customFontSize : Kirigami.Theme.smallFont.pixelSize
+                        Layout.alignment: Qt.AlignCenter
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
+            }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: root.expanded = !root.expanded
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // FULL REPRESENTATION (Popup)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    fullRepresentation: Item {
+        Layout.minimumWidth: Kirigami.Units.gridUnit * 25
+        Layout.preferredWidth: Kirigami.Units.gridUnit * 30
+        Layout.minimumHeight: Kirigami.Units.gridUnit * 8
+        Layout.preferredHeight: {
+            var baseHeight = Kirigami.Units.gridUnit * 5;
+            var deviceHeight = root.allDevices.length * Kirigami.Units.gridUnit * 4;
+            var totalHeight = baseHeight + deviceHeight;
+            var maxHeight = Kirigami.Units.gridUnit * 17;
+            return Math.min(totalHeight, maxHeight);
+        }
+        Layout.maximumHeight: Kirigami.Units.gridUnit * 35
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: Kirigami.Units.largeSpacing
+            spacing: Kirigami.Units.smallSpacing
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Kirigami.Units.smallSpacing
+
+                PlasmaComponents.Label {
+                    text: i18n("Device Battery Levels")
+                    font.bold: true
+                    font.pixelSize: Kirigami.Theme.defaultFont.pixelSize * 1.2
+                    Layout.fillWidth: true
+                }
+
+                PlasmaComponents.ToolButton {
+                    icon.name: "view-refresh"
+                    text: i18n("Refresh")
+                    display: PlasmaComponents.AbstractButton.IconOnly
+
+                    PlasmaComponents.ToolTip {
+                        text: i18n("Refresh devices")
+                    }
+
+                    onClicked: {
+                        refreshDevices();
+                    }
+                }
+            }
+
+            PlasmaComponents.ScrollView {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                clip: true
+
+                PlasmaComponents.ScrollBar.horizontal.policy: PlasmaComponents.ScrollBar.AlwaysOff
+
+                ColumnLayout {
+                    width: parent.parent.width - Kirigami.Units.largeSpacing
+                    spacing: 0
+
+                    Repeater {
+                        model: root.allDevices
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 0
+
+                            // Store reference to device for nested components
+                            property var device: modelData
+                            property bool hasMultipleBatteries: device.batteries && device.batteries.length > 1
+
+                            Item {
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: Kirigami.Units.gridUnit * 4
+                                Layout.topMargin: Kirigami.Units.smallSpacing
+                                Layout.bottomMargin: Kirigami.Units.smallSpacing
+
+                                RowLayout {
+                                    anchors.fill: parent
+                                    spacing: Kirigami.Units.smallSpacing
+
+                                    Kirigami.Icon {
+                                        source: device.icon
+                                        Layout.preferredWidth: Kirigami.Units.iconSizes.medium
+                                        Layout.preferredHeight: Kirigami.Units.iconSizes.medium
+                                        Layout.alignment: Qt.AlignVCenter
+                                    }
+
+                                    ColumnLayout {
+                                        Layout.fillWidth: true
+                                        Layout.alignment: Qt.AlignVCenter
+                                        spacing: 2
+
+                                        PlasmaComponents.Label {
+                                            text: device.name || i18n("Unknown Device")
+                                            font.bold: true
+                                            Layout.fillWidth: true
+                                            elide: Text.ElideRight
+                                        }
+
+                                        PlasmaComponents.Label {
+                                            text: device.serial
+                                            font.pixelSize: Kirigami.Theme.smallFont.pixelSize
+                                            color: Kirigami.Theme.disabledTextColor
+                                            Layout.fillWidth: true
+                                            elide: Text.ElideRight
+                                        }
+
+                                        // Multi-battery row (shown under MAC address)
+                                        RowLayout {
+                                            visible: hasMultipleBatteries
+                                            Layout.fillWidth: true
+                                            spacing: Kirigami.Units.largeSpacing
+
+                                            Repeater {
+                                                model: hasMultipleBatteries ? device.batteries : []
+
+                                                PlasmaComponents.Label {
+                                                    text: {
+                                                        var bat = modelData;
+                                                        var label = bat.label || i18n("Battery");
+                                                        var charging = bat.charging ? " ⚡" : "";
+                                                        // i18n: %1 is the battery label or simply the word, ‘Battery’. %2 is the charge percentage value.
+                                                        // %3 is a Unicode lightning symbol displayed when the device is charging.
+                                                        return i18n("%1: %2%%3", label, bat.percentage, charging);
+                                                    }
+                                                    font.pixelSize: Kirigami.Theme.smallFont.pixelSize
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    RowLayout {
+                                        Layout.alignment: Qt.AlignVCenter
+
+                                        PlasmaComponents.ToolButton {
+                                            visible: device.connectionType === 2 && device.bluetoothAddress
+                                            icon.name: "network-disconnect"
+                                            text: i18n("Disconnect")
+                                            display: PlasmaComponents.AbstractButton.IconOnly
+                                            onClicked: disconnectBluetoothDevice(device.bluetoothAddress)
+
+                                            PlasmaComponents.ToolTip {
+                                                text: i18n("Disconnect device")
+                                            }
+
+                                            MouseArea {
+                                                anchors.fill: parent
+                                                hoverEnabled: true
+                                                cursorShape: Qt.PointingHandCursor
+                                                onPressed: mouse.accepted = false
+                                            }
+                                        }
+
+                                        PlasmaComponents.ToolButton {
+                                            icon.name: root.hiddenDevices.indexOf(device.serial) === -1 ? "view-visible" : "view-hidden"
+                                            text: root.hiddenDevices.indexOf(device.serial) === -1 ? i18n("Hide") : i18n("Show")
+                                            display: PlasmaComponents.AbstractButton.IconOnly
+                                            onClicked: toggleDeviceVisibility(device.serial)
+
+                                            PlasmaComponents.ToolTip {
+                                                text: root.hiddenDevices.indexOf(device.serial) === -1 ? i18n("Hide from tray") : i18n("Show in tray")
+                                            }
+
+                                            MouseArea {
+                                                anchors.fill: parent
+                                                hoverEnabled: true
+                                                cursorShape: Qt.PointingHandCursor
+                                                onPressed: mouse.accepted = false
+                                            }
+                                        }
+
+                                        // Single battery: show percentage
+                                        PlasmaComponents.Label {
+                                            visible: !hasMultipleBatteries
+                                            text: i18n("%1%", device.percentage)
+                                            font.bold: true
+                                            Layout.minimumWidth: Kirigami.Units.gridUnit * 2
+                                            horizontalAlignment: Text.AlignRight
+                                        }
+                                    }
+                                }
+                            }
+
+                            Kirigami.Separator {
+                                Layout.fillWidth: true
+                                visible: index < root.allDevices.length - 1
+                            }
+                        }
+                    }
+
+                    PlasmaComponents.Label {
+                        visible: root.allDevices.length === 0
+                        text: i18n("No connected devices with battery info found")
+                        Layout.fillWidth: true
+                        Layout.topMargin: Kirigami.Units.largeSpacing
+                        horizontalAlignment: Text.AlignHCenter
+                        color: Kirigami.Theme.disabledTextColor
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Summary
- Cleaned up `main.xml` to properly group config entries and added new ones 
- Reworked the Appearance config UI to allow for more granular control over the system tray font styling
- Added local/IDE/LS generated files to `.gitignore`

### UI changes
<img width="667" height="643" alt="image" src="https://github.com/user-attachments/assets/3a5d64f6-f559-49bc-a5e5-3bedf2be36a3" />

<img width="811" height="667" alt="image" src="https://github.com/user-attachments/assets/1a01c1ad-c6bc-4b5d-8f05-ecf3b753abbb" />

- Updated category icon for Appearance to follow common practice used in other popular applets `contents/config/main.xml:L7`

### Notes
- A large portion of the diff is due to automatic QML formatting applied by `qmlls`
  in Neovim, sorry for that
- The only changes in `main.qml` are limited to `contents/ui/main.qml:L300–L310`

No functional behaviour changes has been done outside of config/UI updates