### PR TITLE
add BluezQt provider for Bluetooth device battery

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -131,6 +131,15 @@
     </entry>
   </group>
 
+  <group name="Bluez">
+    <entry name="enableBluezIntegration" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="bluezPollingTime" type="Int">
+      <default>5</default>
+    </entry>
+  </group>
+
   <group name="HID">
     <entry name="enableHIDIntegration" type="Bool">
       <default>true</default>

--- a/contents/ui/config/Modules.qml
+++ b/contents/ui/config/Modules.qml
@@ -16,6 +16,9 @@ KCMUtils.SimpleKCM {
     property alias cfg_enableKDEConnectIntegration: enableKDEConnectIntegration.checked
     property alias cfg_kdeConnectPollingTime: kdeConnectPollingTime.value
 
+    property alias cfg_enableBluezIntegration: enableBluezIntegration.checked
+    property alias cfg_bluezPollingTime: bluezPollingTime.value
+
     property alias cfg_enableHIDIntegration: enableHIDIntegration.checked
     property alias cfg_hidPollingTime: hidPollingTime.value
 
@@ -118,6 +121,46 @@ KCMUtils.SimpleKCM {
                 QQC2.ToolTip {
                     visible: kdeConnectPollingHelp.hovered
                     text: i18n("Sets the interval for KDE Connect device state updates.")
+                }
+            }
+        }
+
+        Item {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Bluez Integration")
+            // Reads Bluetooth device batteries directly from BlueZ (via BluezQt).
+        }
+
+        QQL.RowLayout {
+            Kirigami.FormData.label: i18n("Enable")
+
+            QQC2.CheckBox {
+                id: enableBluezIntegration
+            }
+        }
+
+        QQL.RowLayout {
+            Kirigami.FormData.label: i18n("Polling interval")
+
+            QQC2.SpinBox {
+                id: bluezPollingTime
+                enabled: enableBluezIntegration.checked
+                from: 1
+                to: 3600
+            }
+
+            QQC2.Label {
+                text: i18n("s")
+                opacity: enableBluezIntegration.checked ? 0.7 : 0.5
+            }
+
+            QQC2.ToolButton {
+                id: bluezPollingHelp
+                icon.name: "help-about"
+
+                QQC2.ToolTip {
+                    visible: bluezPollingHelp.hovered
+                    text: i18n("Sets the interval for polling BlueZ device battery updates.\nBlueZ also pushes updates via signals, so this is a safety net.")
                 }
             }
         }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -18,6 +18,13 @@ PlasmoidItem {
         id: upowerProvider
     }
 
+    BluezProvider {
+        id: bluezProvider
+        // Reads Bluetooth device batteries directly from BlueZ (via BluezQt).
+        // the Bluetooth GATT Battery Service but not through UPower.
+        // Placed after UPowerProvider so its data can override 0% UPower entries
+    }
+
     CompanionProvider {
         id: companionProvider
     }
@@ -38,8 +45,7 @@ PlasmoidItem {
         id: hidDevicesProvider
     }
 
-    // List of providers (in priority order)
-    property var providers: [upowerProvider, companionProvider, openLinkHubProvider, openRazerProvider, kdeConnectProvider, hidDevicesProvider]
+    property var providers: [upowerProvider, bluezProvider, companionProvider, openLinkHubProvider, openRazerProvider, kdeConnectProvider, hidDevicesProvider]
 
     // Debug mode
     property bool debugMode: Plasmoid.configuration.debugMode
@@ -123,11 +129,27 @@ PlasmoidItem {
 
             for (var i = 0; i < devices.length; i++) {
                 var device = devices[i];
-                var id = device.serial || device.objectPath || "";
+                // Normalise to lowercase for case-insensitive dedup
+                // the same device's Bluetooth MAC address can appear as "AA:BB:CC:..." from BluezProvider and
+                // "aa:bb:cc:..." from UPowerProvider, which causes a dublicate device, therefore avoiding dublication
+                var id = (device.serial || device.objectPath || "").toLowerCase();
 
-                if (id && !seenIds[id]) {
-                    merged.push(device);
-                    seenIds[id] = true;
+                if (id) {
+                    var existing = seenIds[id];
+                    if (existing === undefined) {
+                        merged.push(device);
+                        seenIds[id] = merged.length - 1;
+                    } else {
+                        var existingDevice = merged[existing];
+                        // When two providers report the same device, keep the
+                        // one with a valid >0% battery and discard the 0% entry.
+                        // This way BluezProvider's correct percentage replaces
+                        // UPowerProvider's 0%
+                        if ((existingDevice.percentage === undefined || existingDevice.percentage <= 0) &&
+                            device.percentage > 0) {
+                            merged[existing] = device;
+                        }
+                    }
                 }
             }
         }

--- a/contents/ui/providers/BluezProvider.qml
+++ b/contents/ui/providers/BluezProvider.qml
@@ -1,0 +1,184 @@
+import QtQuick 2.15
+import org.kde.bluezqt as BluezQt
+import org.kde.plasma.plasma5support 2.0 as P5Support
+import org.kde.plasma.plasmoid 2.0
+import "../DeviceUtils.js" as DeviceUtils
+
+// BluezProvider: reads Bluetooth device battery levels directly from BlueZ
+// via the org.kde.bluezqt QML module (BluezQt.Manager).
+//
+// Some Bluetooth devices (e.g. 8bitdo controllers :( )) expose battery info through
+// the Bluetooth GATT Battery Service but NOT through UPower. The system
+// Bluetooth menu reads this data from BlueZ directly.
+//
+// This provider is the fix for devices that show 0% in UPower-based providers
+// but report correct battery in the Bluetooth settings panel.
+//
+// SOURCES / REFERENCES:
+// - BluezQt QML API:     https://api.kde.org/frameworks/bluez-qt/html/
+// - BluezQt Device.h      https://invent.kde.org/libraries/bluez-qt/-/blob/master/src/device.h
+//   (enum values for type: Keyboard=8, Mouse=9, Joypad=10, Gamepad=11, etc.)
+// - MBattery (approach):  https://github.com/MCC45TR/Plasma6Widgets/tree/main/battery
+//   (uses the same BluezQt.Manager + dev.battery.percentage pattern)
+// - UPowerProvider.qml:   same-directory reference for bluetoothctl disconnect pattern
+// - KDEConnectProvider:   same-directory reference for config toggle + polling pattern
+// - DeviceUtils.js:       same-directory reference for getIconForType()
+// - main.qml:             mergeDevices() expects the device object shape defined here
+Item {
+    id: root
+    visible: false
+
+    // Exposed device list consumed by main.qml's mergeDevices()
+    property var devices: []
+
+    // Connection type constant matching the existing convention:
+    // 0 = wired, 1 = wireless, 2 = bluetooth
+    readonly property int bluetoothType: 2
+
+    // Config toggle (default: true, set in main.xml under group "Bluez")
+    property bool bluezEnabled: Plasmoid.configuration.enableBluezIntegration
+
+    // Clear or populate devices when the toggle changes
+    onBluezEnabledChanged: {
+        if (!bluezEnabled) {
+            devices = []
+        } else {
+            updateDevices()
+        }
+    }
+
+    // BluezQt.Manager — the singleton that gives us access to all Bluetooth
+    // devices known to BlueZ. Its .devices[] array contains all paired devices;
+    // each has .connected, .battery (with .percentage), .name, .address, .type, etc.
+    // Docs: https://api.kde.org/frameworks/bluez-qt/html/classBluezQt_1_1Manager.html
+    property BluezQt.Manager btManager: BluezQt.Manager
+
+    // Called externally by main.qml's refreshDevices()
+    function refresh() {
+        updateDevices()
+    }
+
+    // Core: iterate all BlueZ devices, pick connected ones that expose a
+    // battery percentage >= 0, and build a device object for each.
+    // The device object shape matches what main.qml's mergeDevices() expects
+    // (see: main.qml -> fullRepresentation -> device properties used).
+    function updateDevices() {
+        if (!btManager.operational) {
+            devices = []
+            return
+        }
+
+        var newDevices = []
+        for (var i = 0; i < btManager.devices.length; i++) {
+            var dev = btManager.devices[i]
+            if (dev.connected && dev.battery) {
+                var per = dev.battery.percentage
+                if (per >= 0) {
+                    var deviceType = getDeviceType(dev)
+                    newDevices.push({
+                        name: dev.name,
+                        serial: dev.address,              // Bluetooth MAC address — used for dedup in mergeDevices()
+                        icon: DeviceUtils.getIconForType(deviceType),
+                        percentage: per,
+                        charging: false,                   // BlueZ doesn't expose charging state for BT devices
+                        connectionType: bluetoothType,
+                        source: "bluez",
+                        bluetoothAddress: dev.address,
+                        disconnect: makeDisconnect(dev.address),
+                        disconnectTooltip: i18n("Disconnect Bluetooth device")
+                    })
+                }
+            }
+        }
+        devices = newDevices
+    }
+
+    // Creates a disconnect closure that runs bluetoothctl with the device's MAC
+    // Same approach as UPowerProvider.qml's disconnect for Bluetooth devices.
+    function makeDisconnect(address) {
+        return function() {
+            disconnectSource.connectSource("bluetoothctl disconnect " + address)
+        }
+    }
+
+    // Maps a BlueZ device to a DeviceUtils-compatible type string.
+    // First tries name keyword matching (catches most devices regardless of
+    // BlueZ classification), then falls back to the numeric BlueZ Device.Type enum.
+    //
+    // Name-matching approach inspired by MBattery's getBluetoothIcon().
+    // Enum values from BluezQt Device.h:
+    // https://invent.kde.org/libraries/bluez-qt/-/blob/master/src/device.h
+    //   1=Phone, 3=Computer, 5=Headset, 6=Headphones, 8=Keyboard, 9=Mouse,
+    //   10=Joypad, 11=Gamepad, 12=Tablet, 17=Display, 18=Wearable, 31=Smartphone,
+    //   32=Laptop, 33=Watch
+    function getDeviceType(dev) {
+        var name = (dev.name || "").toLowerCase()
+
+        if (name.indexOf("gamepad") !== -1 || name.indexOf("controller") !== -1 || name.indexOf("joy") !== -1 || name.indexOf("8bitdo") !== -1)
+            return "gamepad"
+        if (name.indexOf("mouse") !== -1 && name.indexOf("keyboard") === -1)
+            return "mouse"
+        if (name.indexOf("keyboard") !== -1 || name.indexOf("keypad") !== -1)
+            return "keyboard"
+        if (name.indexOf("headset") !== -1)
+            return "headset"
+        if (name.indexOf("headphone") !== -1 || name.indexOf("earphone") !== -1 || name.indexOf("earbud") !== -1)
+            return "headphones"
+        if (name.indexOf("speaker") !== -1)
+            return "headphones"
+        if (name.indexOf("phone") !== -1 || name.indexOf("mobile") !== -1)
+            return "phone"
+        if (name.indexOf("tablet") !== -1 || name.indexOf("ipad") !== -1)
+            return "tablet"
+        if (name.indexOf("watch") !== -1 || name.indexOf("band") !== -1)
+            return "watch"
+        if (name.indexOf("laptop") !== -1 || name.indexOf("notebook") !== -1)
+            return "laptop"
+
+        switch (dev.type) {
+            case 8: return "keyboard"
+            case 9: return "mouse"
+            case 10: case 11: return "gamepad"
+            case 12: return "tablet"
+            case 1: case 31: return "phone"
+            case 5: return "headset"
+            case 6: return "headphones"
+            case 18: case 33: return "watch"
+            case 17: return "display"
+            case 32: return "laptop"
+            case 3: return "computer"
+            default: return "gamepad"
+        }
+    }
+
+    // Executable data source used to run bluetoothctl for disconnect.
+    // Same pattern as UPowerProvider.qml's btDisconnectSource.
+    P5Support.DataSource {
+        id: disconnectSource
+        engine: "executable"
+        interval: 0
+        onNewData: (src, data) => disconnectSource(src)
+    }
+
+    // React to BlueZ events in real time rather than only polling.
+    // Same signal-binding pattern as MBattery's DeviceModel.qml.
+    // BluezQt.Manager signals:
+    // https://api.kde.org/frameworks/bluez-qt/html/classBluezQt_1_1Manager.html#signals
+    Connections {
+        target: btManager
+        function onDeviceAdded() { updateDevices() }
+        function onDeviceChanged() { updateDevices() }
+        function onDeviceRemoved() { updateDevices() }
+        function onOperationalChanged() { updateDevices() }
+    }
+
+    // Fallback polling timer in case BlueZ events are missed.
+    // Same pattern as KDEConnectProvider.qml's polling Timer.
+    // Interval is read from config (seconds), default 5s.
+    Timer {
+        interval: Plasmoid.configuration.bluezPollingTime * 1000
+        running: true
+        repeat: true
+        onTriggered: updateDevices()
+    }
+}


### PR DESCRIPTION
Some Bluetooth devices (e.g. 8bitdo controllers) expose battery level through the Bluetooth GATT Battery Service but not through UPower. The system Bluetooth menu reads this data from BlueZ directly.

This merge adds a new BluezProvider that uses BluezQt.Manager to read battery percentages directly from BlueZ, bypassing UPower entirely. The provider is integrated into the existing multi-provider pipeline:

- New file: contents/ui/providers/BluezProvider.qml
- Case-insensitive serial dedup in mergeDevices():
- -  the same device's Bluetooth MAC address can appear as "AA:BB:CC:..." from BluezProvider and "aa:bb:cc:..." from UPowerProvider, which causes a dublicate device, therefore avoiding dublication
- Prefers non-zero percentage when two providers report the same
  device (BlueZ data replaces UPower's 0% entries)
  
  
 before: 
<img width="543" height="492" alt="Screenshot_20260729_203613" src="https://github.com/user-attachments/assets/648824b3-31ee-40eb-a293-c2f7b54d4158" />
  
after :
<img width="510" height="331" alt="Screenshot_20260729_212052" src="https://github.com/user-attachments/assets/50c77a97-2e76-40b0-86b1-f0d31082baa8" />
