### PR TITLE
Add ROG Azoth battery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | **OpenLinkHub** | Corsair and other devices managed by [OpenLinkHub](https://github.com/jurkovic-nikola/OpenLinkHub) |
 | **OpenRazer** | Razer peripherals via [OpenRazer](https://openrazer.github.io/) |
 | **KDE Connect** | Battery levels of paired KDE Connect devices (phones, tablets, etc), with easy unpair action |
-| **HID Devices** | Peripherals read directly via Linux HID (currently supports Steam Controller 2 & Keychron M5) |
+| **HID Devices** | Peripherals read directly via Linux HID (currently supports Steam Controller 2, Keychron M5 & ROG Azoth) |
 
 ## Installation
 

--- a/contents/bin/read_hid_devices
+++ b/contents/bin/read_hid_devices
@@ -16,6 +16,8 @@ Organized in sections mirroring the concerns:
   cli     - JSON output consumed by the widget
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re
@@ -154,6 +156,7 @@ class Device(NamedTuple):
     variants:       tuple[DeviceVariant, ...]            # VID, PID, iface used by device - used as path for where to look up device data
     source:         InputStreamSchema | RequestSchema    # How power is read
     parse:          Callable | None                      # Custom parser: parse(buffers) -> {"percentage", "charging"} | None | KEEP_READING (not a battery frame, keep waiting); None = generic interpret()
+    serial_resolver: Callable | None = None              # Optional resolver(path, vid, pid, uevent_fields) -> serial
 
 # iface = None means that any interface contains battery data
 
@@ -217,6 +220,13 @@ def _logitech_headset(name, cmd, curve, *pids, usage_page=0xFF43, iface=None):
         ),
         parse=_logitech_voltage_parse(curve),
     )
+
+
+def _azoth_serial_resolver(path, vid, pid, fields):
+    """Use Azoth's clean USB serial before its malformed HID serial."""
+    return (usb_serial(path, vid, pid)
+            or printable_serial(fields.get("HID_UNIQ", ""))
+            or "unknown-hid")
 
 
 KNOWN_DEVICES = [
@@ -330,6 +340,7 @@ KNOWN_DEVICES = [
             reply_prefix=bytes.fromhex("001201"),
         ),
         parse=None,
+        serial_resolver=_azoth_serial_resolver,
     ),
     # ── Logitech headsets ──────────────────────────────────────────────────
     _logitech_headset("Logitech G733/G933/G935", (0x08, 0x0A), G633_CURVE, 0x0A5B, 0x0A87, 0x0AB5, 0x0AFE, 0x0B1F),
@@ -355,7 +366,6 @@ class FoundDevice(NamedTuple):
 _HID_ID_RE = re.compile(r"[0-9a-fA-F]+:([0-9a-fA-F]+):([0-9a-fA-F]+)$")
 # HID_PHYS=<phys-path>/input<iface> e.g. "usb-0000:00:14.0-11/input4" -> phys, iface
 _HID_PHYS_RE = re.compile(r"(.*)/input(\d*)")
-_AZOTH_IDS = {(0x0B05, 0x1A83), (0x0B05, 0x1A85), (0x0B05, 0x1ACE)}
 
 def printable_serial(value):
     """Keep the printable prefix of a device-provided serial string."""
@@ -387,7 +397,8 @@ def usb_serial(path, vid, pid):
         current = os.path.dirname(current)
     return None
 
-# Reads sysfs uevent file -> (vid, pid, iface, serial, phys) or None on failure
+# Reads sysfs uevent file -> (vid, pid, iface, fields, phys) or None on failure.
+# Serial resolution is device-specific, so it deliberately happens after matching.
 def parse_uevent(path):
     try:
         with open(path, "r") as file:
@@ -414,17 +425,7 @@ def parse_uevent(path):
         phys = m.group(1)   # shared across a device's interfaces
         iface = int(m.group(2)) if m.group(2) else -1
 
-    if (vid, pid) in _AZOTH_IDS:
-        # Azoth USB descriptors append malformed bytes to its serial. Limit
-        # the workaround to these profiles so existing HID identities retain
-        # their previous behavior.
-        serial = (usb_serial(path, vid, pid)
-                  or printable_serial(fields.get("HID_UNIQ", ""))
-                  or "unknown-hid")
-    else:
-        serial = fields.get("HID_UNIQ", "") or "unknown-hid"
-
-    return vid, pid, iface, serial, phys
+    return vid, pid, iface, fields, phys
 
 # Walks a raw HID report descriptor for its usage pages. Item byte: bits 0-1
 # size (0/1/2/4), bits 2-3 type, bits 4-7 tag. Usage Page = Global/tag 0,
@@ -465,8 +466,8 @@ def hid_usage_pages(path):
     except OSError:
         return set()
 
-# Returns the matching Device and transport variant for a given vid/pid/iface,
-# or None. A variant may constrain the interface, descriptor usage page, or schema.
+# Returns the matching Device and variant for a given vid/pid/iface, or None.
+# A variant may constrain the interface, the descriptor usage page, or both.
 def match_device(vid, pid, iface, usage_pages=None):
     for dev in KNOWN_DEVICES:
         if vid != dev.vid:
@@ -557,13 +558,17 @@ def find_devices():
         parsed = parse_uevent(f"/sys/class/hidraw/{name}/device/uevent")
         if parsed is None:
             continue
-        vid, pid, iface, serial, phys = parsed
+        vid, pid, iface, fields, phys = parsed
 
         usage_pages = hid_usage_pages(f"/sys/class/hidraw/{name}/device/report_descriptor") if pid in _USAGE_PAGE_PIDS else set()
         matched = match_device(vid, pid, iface, usage_pages)
         if matched is None:
             continue
         desc, variant = matched
+
+        serial = (desc.serial_resolver(f"/sys/class/hidraw/{name}/device/uevent", vid, pid, fields)
+                  if desc.serial_resolver is not None
+                  else fields.get("HID_UNIQ", "") or "unknown-hid")
 
         # One entry per physical device: iface=None matches every interface, so
         # skip ones already taken (phys is shared across a device's interfaces)
@@ -584,7 +589,7 @@ def find_devices():
 # access level the schema needs (missing udev rule). Asleep devices *can* be
 # opened, so this only fires for a genuine permissions problem.
 def is_blocked(dev):
-    needs_write = isinstance(dev.desc.source, RequestSchema)
+    needs_write = isinstance(dev.source, RequestSchema)
     flags = os.O_RDWR if needs_write else os.O_RDONLY
     try:
         fd = os.open(dev.devpath, flags | os.O_NONBLOCK)

--- a/contents/bin/read_hid_devices
+++ b/contents/bin/read_hid_devices
@@ -49,6 +49,7 @@ class DeviceType(Enum):
 class DeviceVariant(NamedTuple):
     pid:    int         # Product ID
     iface:  int | None  # Interface
+    source: InputStreamSchema | RequestSchema | None = None  # Optional schema overriding the device default
 
 # A helper class; holds where a specific data byte is stored: report/msg ID + data byte offset
 class DataPos(NamedTuple):
@@ -83,10 +84,13 @@ class RequestSchema(NamedTuple):
     status:       DataPos | ChargingStates | None
     request:      bytes                           # Packet to send before reading; device replies with battery report
     timeout:      float = REQUEST_TIMEOUT_SEC     # Max wait for the reply; devices answer in milliseconds
+    reply_prefix: bytes | None = None             # Expected reply prefix; None keeps the common report-ID + command echo check
 
     def valid(self, buf) -> bool:
         # A real battery reply echoes the request's command byte, which tells it
         # apart from unrelated reports on the same interface.
+        if self.reply_prefix is not None:
+            return len(buf) >= len(self.reply_prefix) and buf[:len(self.reply_prefix)] == self.reply_prefix
         if len(self.request) < 2:
             return True
         return buf[0] == self.charge.report_id and buf[1] == self.request[1]
@@ -200,6 +204,67 @@ KNOWN_DEVICES = [
             )
         ),
         parse=None,
+    ),
+    Device(
+        name="ROG Azoth",
+        device_type=DeviceType.KEYBOARD,
+        vid=0x0B05,
+        variants=(
+            # Standard Azoth transports answer battery queries only on input1.
+            # Match the exact HID_PHYS suffix so no command is sent to other
+            # keyboard collections.
+            # Wired USB exposes a 64-byte vendor report without a report ID.
+            # Linux therefore sees 12:01 at bytes 0:1; every payload offset
+            # is one lower than in the report-ID-prefixed protocol.
+            DeviceVariant(
+                0x1A83, 1,
+                RequestSchema(
+                    charge=DataPos(0x12, 5),
+                    charge_range=None,
+                    status=ChargingStates(
+                        pos=DataPos(0x12, 8),
+                        states={0x01: True},
+                    ),
+                    request=bytes.fromhex("1201") + b"\x00" * 62,
+                    timeout=REQUEST_TIMEOUT_SEC,
+                    reply_prefix=bytes.fromhex("1201"),
+                ),
+            ),
+            # Standard Azoth 2.4 GHz dongle (PID 1A85).
+            # OMNI receivers are distinct and use the 1ACE profile below.
+            DeviceVariant(0x1A85, 1),
+            # The OMNI receiver exposes keyboard, mouse, vendor, and media
+            # collections.  Its vendor collection is input2 (mi_02&col02),
+            # and uses report ID 2 with 64-byte reports.
+            DeviceVariant(
+                0x1ACE, 2,
+                RequestSchema(
+                    charge=DataPos(0x02, 6),
+                    charge_range=None,
+                    status=ChargingStates(
+                        pos=DataPos(0x02, 9),
+                        states={0x01: True},
+                    ),
+                    request=bytes.fromhex("021201") + b"\x00" * 61,
+                    timeout=REQUEST_TIMEOUT_SEC,
+                    reply_prefix=bytes.fromhex("021201"),
+                ),
+            ),
+        ),
+        # The 65-byte 00:12:01 request is echoed by the battery response;
+        # byte 6 is percentage and only state 1 at byte 9 means charging.
+        source=RequestSchema(
+            charge=DataPos(0x00, 6),
+            charge_range=None,
+            status=ChargingStates(
+                pos=DataPos(0x00, 9),
+                states={0x01: True},
+            ),
+            request=bytes.fromhex("001201") + b"\x00" * 62,
+            timeout=REQUEST_TIMEOUT_SEC,
+            reply_prefix=bytes.fromhex("001201"),
+        ),
+        parse=None,
     )
 ]
 
@@ -209,6 +274,7 @@ class FoundDevice(NamedTuple):
     serial:  str
     desc:    Device
     pid:     int       # Product ID that actually matched (from sysfs)
+    source:  InputStreamSchema | RequestSchema
 
 # ══════════════════════════════════════════════════════════════════════════
 # hid - sysfs discovery + hidraw I/O
@@ -217,6 +283,37 @@ class FoundDevice(NamedTuple):
 _HID_ID_RE = re.compile(r"[0-9a-fA-F]+:([0-9a-fA-F]+):([0-9a-fA-F]+)$")
 # HID_PHYS=<phys-path>/input<iface> e.g. "usb-0000:00:14.0-11/input4" -> phys, iface
 _HID_PHYS_RE = re.compile(r"(.*)/input(\d*)")
+_AZOTH_IDS = {(0x0B05, 0x1A83), (0x0B05, 0x1A85), (0x0B05, 0x1ACE)}
+
+def printable_serial(value):
+    """Keep the printable prefix of a device-provided serial string."""
+    value = value.strip()
+    for index, char in enumerate(value):
+        if not char.isprintable():
+            value = value[:index]
+            break
+    return value or None
+
+# Returns the USB device serial for this HID node when its parent exposes one.
+# Some devices append malformed bytes to their string descriptor, so retain
+# only its printable prefix before using it as the widget's device identity.
+def usb_serial(path, vid, pid):
+    current = os.path.realpath(os.path.dirname(path))
+    while current != os.path.dirname(current):
+        try:
+            with open(f"{current}/idVendor", "r") as file:
+                parent_vid = int(file.read().strip(), 16)
+            with open(f"{current}/idProduct", "r") as file:
+                parent_pid = int(file.read().strip(), 16)
+            if parent_vid == vid and parent_pid == pid:
+                with open(f"{current}/serial", "r") as file:
+                    serial = printable_serial(file.read())
+                if serial:
+                    return serial
+        except (OSError, ValueError):
+            pass
+        current = os.path.dirname(current)
+    return None
 
 # Reads sysfs uevent file -> (vid, pid, iface, serial, phys) or None on failure
 def parse_uevent(path):
@@ -246,11 +343,20 @@ def parse_uevent(path):
         phys = m.group(1)   # shared across a device's interfaces
         iface = int(m.group(2)) if m.group(2) else -1
 
-    serial = fields.get("HID_UNIQ", "") or "unknown-hid"
+    if (vid, pid) in _AZOTH_IDS:
+        # Azoth USB descriptors append malformed bytes to its serial. Limit
+        # the workaround to these profiles so existing HID identities retain
+        # their previous behavior.
+        serial = (usb_serial(path, vid, pid)
+                  or printable_serial(fields.get("HID_UNIQ", ""))
+                  or "unknown-hid")
+    else:
+        serial = fields.get("HID_UNIQ", "") or "unknown-hid"
 
     return vid, pid, iface, serial, phys
 
-# Returns the matching Device for a given vid/pid/iface, or None
+# Returns the matching Device and transport variant for a given vid/pid/iface,
+# or None.  A variant may override the device's default transport schema.
 def match_device(vid, pid, iface):
     for dev in KNOWN_DEVICES:
         if vid != dev.vid:
@@ -261,7 +367,7 @@ def match_device(vid, pid, iface):
             # iface = None in a variant means any interface contains batt data
             if variant.iface is not None and iface != variant.iface:
                 continue
-            return dev
+            return dev, variant
     return None
 
 
@@ -352,9 +458,10 @@ def find_devices():
             continue
         vid, pid, iface, serial, phys = parsed
 
-        desc = match_device(vid, pid, iface)
-        if desc is None:
+        matched = match_device(vid, pid, iface)
+        if matched is None:
             continue
+        desc, variant = matched
 
         # One entry per physical device: iface=None matches every interface, so
         # skip ones already taken (phys is shared across a device's interfaces)
@@ -368,7 +475,7 @@ def find_devices():
         if serial == "unknown-hid":
             serial = phys or name
 
-        devices.append(FoundDevice(f"/dev/{name}", serial, desc, pid))
+        devices.append(FoundDevice(f"/dev/{name}", serial, desc, pid, variant.source or desc.source))
     return devices
 
 # True when the device is present but its hidraw node can't be opened for the
@@ -408,8 +515,12 @@ def open_device(dev, schema):
 # the schema's timeout. O_NONBLOCK + poll() makes it sleep in kernel with 0 CPU
 # utilisation. Returns status dict {"percentage", "charging"} or None.
 def read_status_hw(dev):
-    schema = dev.desc.source
+    schema = dev.source
     needed = needed_reports(schema)
+    # Most devices use 64-byte reports.  Some request-response devices, such
+    # as the ROG Azoth, use a 65-byte report including report ID, so read at
+    # least as much as the schema's request packet.
+    read_size = max(HID_BUFFER_SIZE, len(schema.request)) if isinstance(schema, RequestSchema) else HID_BUFFER_SIZE
 
     fd = open_device(dev, schema)
     if fd is None:
@@ -438,7 +549,7 @@ def read_status_hw(dev):
                 return None
 
             try:
-                buf = os.read(fd, HID_BUFFER_SIZE)
+                buf = os.read(fd, read_size)
             except OSError:
                 return None
             if not buf:

--- a/contents/bin/tests/test_read_hid_devices.py
+++ b/contents/bin/tests/test_read_hid_devices.py
@@ -9,6 +9,9 @@ sysfs + hidraw devices and verifies every behavior the widget depends on:
                   charging decode, wired d048, no-reply handling (device
                   dropped, stateless per run), blocked reporting, dynamic
                   udev rule generation.
+  Azoth (ROG):    Wired, standard 2.4 GHz, and OMNI request-response
+                  transports; their control-interface targeting, battery and
+                  charging-state decode, blocked reporting, and udev rules.
   SC2 (stream):   battery decode from stream report, charging state, no write.
 
 Written as plain pytest-style test_*() functions so they read like idiomatic
@@ -61,18 +64,25 @@ def load_helper():
 
 
 rhd = load_helper()
+unpatched_usb_serial = rhd.usb_serial
 
 # ══════════════════════════════════════════════════════════════════════════
-# Scenario fakes: swap these globals between the M5 and SC2 scenarios
+# Scenario fakes: swap these globals between the M5, SC2, and Azoth scenarios
 # ══════════════════════════════════════════════════════════════════════════
-scenario = {"uevents": {}, "fake_devs": {}, "reply_fd": None, "reply_buf": bytearray(64), "writes": [], "reads": []}
+scenario = {"uevents": {}, "fake_devs": {}, "reply_fd": None, "reply_buf": bytearray(64),
+            "writes": [], "write_data": [], "reads": [], "read_sizes": []}
 
 def m5_uevent(node, pid="0000D028", name="Keychron Keychron Ultra-Link 8K", iface=4):
     return (f"DRIVER=hid-generic\nHID_ID=0003:00003434:{pid}\n"
             f"HID_NAME={name}\nHID_PHYS=usb-0000:00:14.0-11/input{iface}\nHID_UNIQ=\n")
 
+def azoth_uevent(node, pid="00001ACE", iface=1):
+    return (f"DRIVER=hid-generic\nHID_ID=0003:00000B05:{pid}\n"
+            f"HID_NAME=ROG Azoth\nHID_PHYS=usb-0000:00:14.0-12/input{iface}\n"
+            "HID_UNIQ=azoth-simulated-serial\n")
+
 def fake_open(path, mode="r", *a, **k):
-    if path.startswith("/sys/class/hidraw"):
+    if path.startswith("/sys/class/hidraw") and path.endswith("/uevent"):
         return io.StringIO(scenario["uevents"][path.split("/")[4]])
     return builtins.open(path, mode, *a, **k)
 
@@ -85,10 +95,12 @@ def fake_osopen(path, flags):
 
 def fake_write(fd, data):
     scenario["writes"].append(fd)
+    scenario["write_data"].append(bytes(data))
     return len(data)
 
 def fake_read(fd, size):
     scenario["reads"].append(fd)
+    scenario["read_sizes"].append(size)
     if fd == scenario["reply_fd"]:
         return bytes(scenario["reply_buf"])
     return b""
@@ -134,6 +146,21 @@ def install_sc2_scenario():
     scenario["reply_buf"] = bytearray(16)
     scenario["reply_fd"] = 207
 
+def install_azoth_scenario(pid="00001ACE", with_blocked=False):
+    scenario["uevents"] = {
+        "hidraw7": azoth_uevent("hidraw7", pid, 0),
+        "hidraw8": azoth_uevent("hidraw8", pid, 1),
+        "hidraw9": azoth_uevent("hidraw9", pid, 2),
+    }
+    scenario["fake_devs"] = {f"/dev/{key}": 300 + int(key[-1]) for key in scenario["uevents"]}
+    scenario["deny"] = with_blocked
+    scenario["writes"] = []
+    scenario["write_data"] = []
+    scenario["reads"] = []
+    scenario["read_sizes"] = []
+    scenario["reply_buf"] = bytearray(65)
+    scenario["reply_fd"] = 309 if pid == "00001ACE" else 308
+
 def set_m5_reply(byte20=87, report_id=0xB4, cmd=0x06):
     buf = bytearray(64)
     buf[0] = report_id
@@ -152,8 +179,20 @@ def set_sc2_report(state=0x02, pct=85):
     buf[2] = pct
     scenario["reply_buf"] = buf
 
+def set_azoth_reply(pct=73, state=0x00, prefix=bytes.fromhex("021201")):
+    buf = bytearray(64 if prefix[0] in (0x02, 0x12) else 65)
+    buf[:len(prefix)] = prefix
+    battery_offset = 5 if prefix[0] == 0x12 else 6
+    status_offset = 8 if prefix[0] == 0x12 else 9
+    buf[battery_offset] = pct
+    buf[status_offset] = state
+    scenario["reply_buf"] = buf
+
 def patch_module():
     rhd.open = fake_open
+    # Scenario fixtures provide only hidraw uevent files.  Do not let their
+    # parse_uevent() calls walk the host's real sysfs parent hierarchy.
+    rhd.usb_serial = lambda path, vid, pid: None
     rhd.os.open = fake_osopen
     rhd.os.listdir = lambda *a: list(scenario["uevents"].keys())
     rhd.os.write = fake_write
@@ -205,6 +244,49 @@ patch_module()
 # ══════════════════════════════════════════════════════════════════════════
 # Schema / reference behavior
 # ══════════════════════════════════════════════════════════════════════════
+def test_usb_serial_is_preferred_over_malformed_hid_uniq():
+    root = tempfile.mkdtemp()
+    hid_dir = os.path.join(root, "usb", "1-3", "1-3:1.1", "hid")
+    usb_dir = os.path.dirname(os.path.dirname(hid_dir))
+    os.makedirs(hid_dir)
+    for name, value in (("idVendor", "0b05\n"), ("idProduct", "1a83\n"),
+                        ("serial", "S2MPGDD00YNA\n")):
+        with open(os.path.join(usb_dir, name), "w") as file:
+            file.write(value)
+    assert unpatched_usb_serial(os.path.join(hid_dir, "uevent"), 0x0B05, 0x1A83) == "S2MPGDD00YNA"
+
+def test_parse_uevent_prefers_sanitized_usb_parent_serial():
+    root = tempfile.mkdtemp()
+    hid_dir = os.path.join(root, "usb", "1-3", "1-3:1.1", "hid")
+    usb_dir = os.path.dirname(os.path.dirname(hid_dir))
+    os.makedirs(hid_dir)
+    for name, value in (("idVendor", "0b05\n"), ("idProduct", "1a83\n"),
+                        ("serial", "S2MPGDD00YNA\x18\xbe\n")):
+        with open(os.path.join(usb_dir, name), "w") as file:
+            file.write(value)
+    uevent = os.path.join(hid_dir, "uevent")
+    with open(uevent, "w") as file:
+        file.write("HID_ID=0003:00000B05:00001A83\n"
+                   "HID_PHYS=usb-0000:00:14.0-3/input1\n"
+                   "HID_UNIQ=should-not-win\n")
+
+    saved_usb_serial = rhd.usb_serial
+    rhd.usb_serial = unpatched_usb_serial
+    try:
+        parsed = rhd.parse_uevent(uevent)
+    finally:
+        rhd.usb_serial = saved_usb_serial
+    assert parsed[3] == "S2MPGDD00YNA"
+
+def test_parse_uevent_truncates_invalid_hid_uniq():
+    scenario["uevents"] = {
+        "hidraw42": ("HID_ID=0003:00000B05:00001A83\n"
+                      "HID_PHYS=usb-0000:00:14.0-3/input1\n"
+                      "HID_UNIQ=S2MPGDD00YNA\x18\xbe\n"),
+    }
+    parsed = rhd.parse_uevent("/sys/class/hidraw/hidraw42/device/uevent")
+    assert parsed[3] == "S2MPGDD00YNA"
+
 def test_reference_match():
     # Reference match (github.com/itayavra/batterywatch/issues/5)
     dev = rhd.KNOWN_DEVICES[0]
@@ -212,6 +294,32 @@ def test_reference_match():
     assert dev.source.timeout == 1, "request timeout (reference read 128, 1000ms)"
     assert dev.source.charge == rhd.DataPos(0xB4, 20), "battery byte offset (reference data_array[20])"
     assert dev.variants == (rhd.DeviceVariant(0xD028, 4), rhd.DeviceVariant(0xD048, 4))
+
+def test_azoth_reference_profile():
+    azoths = [dev for dev in rhd.KNOWN_DEVICES if dev.name == "ROG Azoth"]
+    assert len(azoths) == 1, "all Azoth transports belong to one device definition"
+    dev = azoths[0]
+    assert dev.device_type == rhd.DeviceType.KEYBOARD
+    wired, wireless = dev.variants[:2]
+    assert (wired.pid, wired.iface) == (0x1A83, 1)
+    assert wired.source.request == bytes.fromhex("1201") + b"\x00" * 62
+    assert wired.source.reply_prefix == bytes.fromhex("1201")
+    assert wired.source.charge == rhd.DataPos(0x12, 5)
+    assert wired.source.status == rhd.ChargingStates(rhd.DataPos(0x12, 8), {0x01: True})
+    assert wireless == rhd.DeviceVariant(0x1A85, 1)
+    assert dev.source.request == bytes.fromhex("001201") + b"\x00" * 62
+    assert dev.source.reply_prefix == bytes.fromhex("001201")
+    assert dev.source.charge == rhd.DataPos(0x00, 6)
+    assert dev.source.status == rhd.ChargingStates(rhd.DataPos(0x00, 9), {0x01: True})
+
+def test_azoth_omni_reference_profile():
+    dev = next(dev for dev in rhd.KNOWN_DEVICES if dev.name == "ROG Azoth")
+    omni = dev.variants[2]
+    assert (omni.pid, omni.iface) == (0x1ACE, 2)
+    assert omni.source.request == bytes.fromhex("021201") + b"\x00" * 61
+    assert omni.source.reply_prefix == bytes.fromhex("021201")
+    assert omni.source.charge == rhd.DataPos(0x02, 6)
+    assert omni.source.status == rhd.ChargingStates(rhd.DataPos(0x02, 9), {0x01: True})
 
 
 # ══════════════════════════════════════════════════════════════════════════
@@ -322,6 +430,83 @@ def test_wired_d048_found_and_decoded():
     devs = rhd.find_devices()
     assert [d.devpath for d in devs] == ["/dev/hidraw6"], f"found: {[d.devpath for d in devs]!r}"
     assert rhd.read_status(devs[0]) == {"percentage": 2, "charging": True}, "byte20=130 -> 2%"
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# ROG Azoth: wired, standard 2.4 GHz, and OMNI request-response transports
+# ══════════════════════════════════════════════════════════════════════════
+def test_azoth_discovery_targets_control_interface_only():
+    install_azoth_scenario()
+    devs = rhd.find_devices()
+    assert [dev.devpath for dev in devs] == ["/dev/hidraw9"]
+    assert devs[0].serial == "azoth-simulated-serial"
+    assert devs[0].pid == 0x1ACE
+
+def test_azoth_wired_and_wireless_variants_are_found():
+    for pid, prefix in (("00001A83", bytes.fromhex("1201")),
+                        ("00001A85", bytes.fromhex("001201"))):
+        install_azoth_scenario(pid=pid)
+        set_azoth_reply(prefix=prefix)
+        devs = rhd.find_devices()
+        assert len(devs) == 1
+        assert rhd.read_status(devs[0]) == {"percentage": 73, "charging": False}
+
+def test_azoth_wired_request_uses_64_byte_unprefixed_report():
+    install_azoth_scenario(pid="00001A83")
+    set_azoth_reply(prefix=bytes.fromhex("1201"))
+    assert rhd.read_status(rhd.find_devices()[0]) == {"percentage": 73, "charging": False}
+    assert scenario["writes"] == [308]
+    assert scenario["write_data"] == [bytes.fromhex("1201") + b"\x00" * 62]
+    assert scenario["read_sizes"] == [64]
+
+def test_azoth_wireless_request_is_one_padded_65_byte_report():
+    install_azoth_scenario(pid="00001A85")
+    set_azoth_reply(prefix=bytes.fromhex("001201"))
+    assert rhd.read_status(rhd.find_devices()[0]) == {"percentage": 73, "charging": False}
+    assert scenario["writes"] == [308]
+    assert scenario["write_data"] == [bytes.fromhex("001201") + b"\x00" * 62]
+    assert scenario["read_sizes"] == [65]
+
+def test_azoth_omni_request_uses_vendor_report_id_and_64_bytes():
+    install_azoth_scenario()
+    set_azoth_reply()
+    assert rhd.read_status(rhd.find_devices()[0]) == {"percentage": 73, "charging": False}
+    assert scenario["writes"] == [309]
+    assert scenario["write_data"] == [bytes.fromhex("021201") + b"\x00" * 61]
+    assert scenario["read_sizes"] == [64]
+
+def test_azoth_decodes_percentage_and_charging_states():
+    for pct, state, charging in ((0, 0, False), (50, 1, True), (100, 2, False)):
+        install_azoth_scenario()
+        set_azoth_reply(pct=pct, state=state)
+        assert rhd.read_status(rhd.find_devices()[0]) == {"percentage": pct, "charging": charging}
+
+def test_azoth_invalid_echo_and_timeout_emit_no_status():
+    install_azoth_scenario()
+    set_azoth_reply(prefix=bytes.fromhex("021200"))
+    assert rhd.read_status(rhd.find_devices()[0]) is None
+
+    install_azoth_scenario()
+    set_azoth_reply(prefix=bytes.fromhex("011201"))
+    assert rhd.read_status(rhd.find_devices()[0]) is None
+
+    install_azoth_scenario()
+    scenario["reply_fd"] = None
+    assert rhd.read_status(rhd.find_devices()[0]) is None
+
+def test_azoth_blocked_entry_and_udev_rule_cover_both_variants():
+    install_azoth_scenario(with_blocked=True)
+    dev = rhd.find_devices()[0]
+    assert rhd.is_blocked(dev) is True
+    entry = rhd._device_entry(dev)
+    assert entry["blocked"] is True
+    assert entry["unblock_command"] == rhd.udev_unblock_command(0x0B05)
+
+    rule = rhd.udev_rule_for(0x0B05)
+    assert 'ATTRS{idProduct}=="1a83"' in rule
+    assert 'ATTRS{idProduct}=="1a85"' in rule
+    assert 'ATTRS{idProduct}=="1ace"' in rule
+    assert rule.count('MODE="0660"') == 3
 
 
 # ══════════════════════════════════════════════════════════════════════════

--- a/contents/bin/tests/test_read_hid_devices.py
+++ b/contents/bin/tests/test_read_hid_devices.py
@@ -71,7 +71,7 @@ unpatched_usb_serial = rhd.usb_serial
 # ══════════════════════════════════════════════════════════════════════════
 scenario = {"uevents": {}, "fake_devs": {}, "reply_fd": None, "reply_buf": bytearray(64),
             "reply_queue": [], "writes": [], "write_data": [], "reads": [], "read_sizes": [],
-            "descriptors": {}, "descriptor_reads": 0}
+            "open_flags": [], "descriptors": {}, "descriptor_reads": 0}
 
 def m5_uevent(node, pid="0000D028", name="Keychron Keychron Ultra-Link 8K", iface=4):
     return (f"DRIVER=hid-generic\nHID_ID=0003:00003434:{pid}\n"
@@ -80,7 +80,7 @@ def m5_uevent(node, pid="0000D028", name="Keychron Keychron Ultra-Link 8K", ifac
 def azoth_uevent(node, pid="00001ACE", iface=1):
     return (f"DRIVER=hid-generic\nHID_ID=0003:00000B05:{pid}\n"
             f"HID_NAME=ROG Azoth\nHID_PHYS=usb-0000:00:14.0-12/input{iface}\n"
-            "HID_UNIQ=azoth-simulated-serial\n")
+            "HID_UNIQ=SN1LAZOTG6C2\n")
 
 def fake_open(path, mode="r", *a, **k):
     if path.startswith("/sys/class/hidraw"):
@@ -92,6 +92,7 @@ def fake_open(path, mode="r", *a, **k):
     return builtins.open(path, mode, *a, **k)
 
 def fake_osopen(path, flags):
+    scenario["open_flags"].append(flags)
     if scenario.get("deny") and path in scenario["fake_devs"]:
         raise PermissionError(13, "Permission denied")
     if path in scenario["fake_devs"]:
@@ -141,6 +142,7 @@ def install_m5_scenario(pid="0000D028", name="Keychron Keychron Ultra-Link 8K", 
     scenario["write_data"] = []
     scenario["reads"] = []
     scenario["read_sizes"] = []
+    scenario["open_flags"] = []
     scenario["reply_buf"] = bytearray(64)
     scenario["reply_queue"] = []
     scenario["reply_fd"] = 306
@@ -159,6 +161,7 @@ def install_sc2_scenario():
     scenario["write_data"] = []
     scenario["reads"] = []
     scenario["read_sizes"] = []
+    scenario["open_flags"] = []
     scenario["reply_buf"] = bytearray(16)
     scenario["reply_queue"] = []
     scenario["reply_fd"] = 207
@@ -185,6 +188,7 @@ def install_g733_scenario(iface=3, usage_page=0xFF43):
     scenario["write_data"] = []
     scenario["reads"] = []
     scenario["read_sizes"] = []
+    scenario["open_flags"] = []
     scenario["reply_buf"] = bytearray(8)
     scenario["reply_queue"] = []
     scenario["reply_fd"] = 208
@@ -203,6 +207,7 @@ def install_azoth_scenario(pid="00001ACE", with_blocked=False):
     scenario["write_data"] = []
     scenario["reads"] = []
     scenario["read_sizes"] = []
+    scenario["open_flags"] = []
     scenario["reply_buf"] = bytearray(65)
     scenario["reply_queue"] = []
     scenario["reply_fd"] = 309 if pid == "00001ACE" else 308
@@ -298,42 +303,45 @@ def test_usb_serial_is_preferred_over_malformed_hid_uniq():
     usb_dir = os.path.dirname(os.path.dirname(hid_dir))
     os.makedirs(hid_dir)
     for name, value in (("idVendor", "0b05\n"), ("idProduct", "1a83\n"),
-                        ("serial", "S2MPGDD00YNA\n")):
+                        ("serial", "SN1LAZOTG6C2\n")):
         with open(os.path.join(usb_dir, name), "w") as file:
             file.write(value)
-    assert unpatched_usb_serial(os.path.join(hid_dir, "uevent"), 0x0B05, 0x1A83) == "S2MPGDD00YNA"
+    assert unpatched_usb_serial(os.path.join(hid_dir, "uevent"), 0x0B05, 0x1A83) == "SN1LAZOTG6C2"
 
-def test_parse_uevent_prefers_sanitized_usb_parent_serial():
+def test_azoth_resolver_prefers_sanitized_usb_parent_serial():
     root = tempfile.mkdtemp()
     hid_dir = os.path.join(root, "usb", "1-3", "1-3:1.1", "hid")
     usb_dir = os.path.dirname(os.path.dirname(hid_dir))
     os.makedirs(hid_dir)
     for name, value in (("idVendor", "0b05\n"), ("idProduct", "1a83\n"),
-                        ("serial", "S2MPGDD00YNA\x18\xbe\n")):
+                        ("serial", "SN1LAZOTG6C2\x18\xbe\n")):
         with open(os.path.join(usb_dir, name), "w") as file:
             file.write(value)
-    uevent = os.path.join(hid_dir, "uevent")
-    with open(uevent, "w") as file:
-        file.write("HID_ID=0003:00000B05:00001A83\n"
-                   "HID_PHYS=usb-0000:00:14.0-3/input1\n"
-                   "HID_UNIQ=should-not-win\n")
-
     saved_usb_serial = rhd.usb_serial
     rhd.usb_serial = unpatched_usb_serial
     try:
-        parsed = rhd.parse_uevent(uevent)
+        serial = rhd._azoth_serial_resolver(
+            os.path.join(hid_dir, "uevent"), 0x0B05, 0x1A83,
+            {"HID_UNIQ": "should-not-win"},
+        )
     finally:
         rhd.usb_serial = saved_usb_serial
-    assert parsed[3] == "S2MPGDD00YNA"
+    assert serial == "SN1LAZOTG6C2"
 
-def test_parse_uevent_truncates_invalid_hid_uniq():
-    scenario["uevents"] = {
-        "hidraw42": ("HID_ID=0003:00000B05:00001A83\n"
-                      "HID_PHYS=usb-0000:00:14.0-3/input1\n"
-                      "HID_UNIQ=S2MPGDD00YNA\x18\xbe\n"),
-    }
-    parsed = rhd.parse_uevent("/sys/class/hidraw/hidraw42/device/uevent")
-    assert parsed[3] == "S2MPGDD00YNA"
+def test_azoth_resolver_truncates_invalid_hid_uniq():
+    assert rhd._azoth_serial_resolver(
+        "unused", 0x0B05, 0x1A83, {"HID_UNIQ": "SN1LAZOTG6C2\x18\xbe"}
+    ) == "SN1LAZOTG6C2"
+
+def test_azoth_resolver_keeps_clean_hid_uniq_byte_exact():
+    assert rhd._azoth_serial_resolver(
+        "unused", 0x0B05, 0x1A83, {"HID_UNIQ": "SN1LAZOTG6C2"}
+    ) == "SN1LAZOTG6C2"
+
+def test_non_azoth_hid_uniq_is_not_resolved_or_sanitized():
+    install_m5_scenario()
+    scenario["uevents"]["hidraw6"] = m5_uevent("hidraw6")[:-1] + "serial\x18\xbe\n"
+    assert rhd.find_devices()[0].serial == "serial\x18\xbe"
 
 def test_reference_match():
     # Reference match (github.com/itayavra/batterywatch/issues/5)
@@ -487,7 +495,7 @@ def test_azoth_discovery_targets_control_interface_only():
     install_azoth_scenario()
     devs = rhd.find_devices()
     assert [dev.devpath for dev in devs] == ["/dev/hidraw9"]
-    assert devs[0].serial == "azoth-simulated-serial"
+    assert devs[0].serial == "SN1LAZOTG6C2"
     assert devs[0].pid == 0x1ACE
 
 def test_azoth_wired_and_wireless_variants_are_found():
@@ -567,6 +575,25 @@ def test_is_blocked_true_on_eacces():
 def test_is_blocked_false_when_readable():
     install_m5_scenario(with_blocked=False)
     assert rhd.is_blocked(rhd.find_devices()[0]) is False
+
+def test_is_blocked_uses_effective_variant_schema_open_mode():
+    # The effective schema can differ from the registry device's default.
+    # Permissions must follow FoundDevice.source, just like reading does.
+    install_m5_scenario()
+    stream_device = next(dev for dev in rhd.KNOWN_DEVICES
+                         if dev.name == "Steam Controller 2")
+    request_device = next(dev for dev in rhd.KNOWN_DEVICES
+                          if dev.name == "Keychron M5")
+    m5 = rhd.find_devices()[0]
+
+    request_variant = rhd.FoundDevice(m5.devpath, m5.serial, stream_device, m5.pid, request_device.source)
+    assert rhd.is_blocked(request_variant) is False
+    assert scenario["open_flags"] == [os.O_RDWR | os.O_NONBLOCK]
+
+    scenario["open_flags"] = []
+    stream_variant = rhd.FoundDevice(m5.devpath, m5.serial, request_device, m5.pid, stream_device.source)
+    assert rhd.is_blocked(stream_variant) is False
+    assert scenario["open_flags"] == [os.O_RDONLY | os.O_NONBLOCK]
 
 
 # ══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
**I implemented this primarily for my own ROG Azoth setup, but thought it might also be useful for other BatteryWatch users.**

Adds direct HID battery support for the ROG Azoth over wired USB, the standard 2.4 GHz dongle, and the ROG OMNI Receiver.

The helper uses the correct request/report format for each transport, validates reply prefixes, handles 65-byte reports where required, and sanitizes malformed Azoth serial data. Existing HID device behavior remains unchanged.

Tests cover discovery, requests, battery/charging decoding, invalid replies, permissions and all three Azoth transports.