### PR TITLE
Add Logitech HID++ 1.0 headset battery support (G533/G535/G Pro/G633/…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## [Unreleased]
 
-## [0.3.2] - 2026-08-04
+## [0.3.2] - 2026-08-22
 
 ### Added
 - **Keychron M5 support** — new request-response HID schema (0xB3:06 request / 0xB4 reply) reads the M5's battery over the vendor interface; works both wireless (Ultra-Link 8K dongle) and wired (USB-C); correct charging decode
+- **Logitech headset support** — battery levels of Logitech G533, G535, G PRO, G733, G933 and G935 headsets, read directly over HID++ request/response; raw battery voltage is mapped to a percentage via per-model calibration curves (protocol details from [HeadsetControl](https://github.com/Sapd/HeadsetControl) and [Solaar](https://github.com/pwr-Solaar-Solaar); not yet verified on real hardware — feedback welcome)
 
 ### Changed
 - **User-run udev authorization** — a device whose battery needs extra permission now shows a lock icon and a "Copy command" button; the user pastes one `sudo tee` command in a terminal on their own terms. A single rule file per device covers all its connection variants (wireless + wired)
@@ -97,6 +98,7 @@
 Initial development releases (v0.1.0 – v0.1.9, through 2026-01-03). Core functionality: monitor battery levels of Bluetooth and wireless devices via UPower, with OpenLinkHub and BatteryWatch Companion integration.
 
 [Unreleased]: https://github.com/itayavra/batterywatch/compare/v0.3.1...HEAD
+[0.3.2]: https://github.com/itayavra/batterywatch/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/itayavra/batterywatch/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/itayavra/batterywatch/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/itayavra/batterywatch/compare/v0.2.1...v0.2.2

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@
 | **OpenLinkHub** | Corsair and other devices managed by [OpenLinkHub](https://github.com/jurkovic-nikola/OpenLinkHub) |
 | **OpenRazer** | Razer peripherals via [OpenRazer](https://openrazer.github.io/) |
 | **KDE Connect** | Battery levels of paired KDE Connect devices (phones, tablets, etc), with easy unpair action |
-| **HID Devices** | Peripherals read directly via Linux HID (currently supports Steam Controller 2 & Keychron M5) |
+| **HID Devices** | Peripherals read directly via Linux HID (currently supports Steam Controller 2, Keychron M5, and Logitech G533/G535/G Pro/G633/G635/G733/G933/G935 headsets) |
+
+> **Note:** Protocol details (commands, PIDs, and battery calibration curves) for the Logitech headsets are sourced from [HeadsetControl](https://github.com/Sapd/HeadsetControl) (GPL-3.0), with attribution in `contents/bin/read_hid_devices`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 | **KDE Connect** | Battery levels of paired KDE Connect devices (phones, tablets, etc), with easy unpair action |
 | **HID Devices** | Peripherals read directly via Linux HID (currently supports Steam Controller 2, Keychron M5, and Logitech G533/G535/G Pro/G733/G933/G935 headsets) |
 
-> **Note:** Protocol details (commands, PIDs, and battery calibration curves) for the Logitech headsets are sourced from [HeadsetControl](https://github.com/Sapd/HeadsetControl) (GPL-3.0), with attribution in `contents/bin/read_hid_devices`. G533, G535, G733, G933 and G935 are confirmed against real device captures; G733 v3, G PRO and G PRO X share the same protocol but are individually unverified, and the G PRO X 2 is intentionally not supported (it uses a different protocol family).
+> **Note:** Protocol details (commands, PIDs, and battery calibration curves) for the Logitech headsets are sourced from [HeadsetControl](https://github.com/Sapd/HeadsetControl) (GPL-3.0) and [Solaar](https://github.com/pwr-Solaar-Solaar), with attribution in `contents/bin/read_hid_devices`. None of the models has been verified on real hardware yet: support for G533, G535, G733, G933, G935 and G PRO X follows Solaar's device data, while G733 v3, G PRO and G PRO X v0 are protocol-shared extrapolations.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@
 | **OpenLinkHub** | Corsair and other devices managed by [OpenLinkHub](https://github.com/jurkovic-nikola/OpenLinkHub) |
 | **OpenRazer** | Razer peripherals via [OpenRazer](https://openrazer.github.io/) |
 | **KDE Connect** | Battery levels of paired KDE Connect devices (phones, tablets, etc), with easy unpair action |
-| **HID Devices** | Peripherals read directly via Linux HID (currently supports Steam Controller 2, Keychron M5, and Logitech G533/G535/G Pro/G633/G635/G733/G933/G935 headsets) |
+| **HID Devices** | Peripherals read directly via Linux HID (currently supports Steam Controller 2, Keychron M5, and Logitech G533/G535/G Pro/G733/G933/G935 headsets) |
 
-> **Note:** Protocol details (commands, PIDs, and battery calibration curves) for the Logitech headsets are sourced from [HeadsetControl](https://github.com/Sapd/HeadsetControl) (GPL-3.0), with attribution in `contents/bin/read_hid_devices`.
+> **Note:** Protocol details (commands, PIDs, and battery calibration curves) for the Logitech headsets are sourced from [HeadsetControl](https://github.com/Sapd/HeadsetControl) (GPL-3.0), with attribution in `contents/bin/read_hid_devices`. G533, G535, G733, G933 and G935 are confirmed against real device captures; G733 v3, G PRO and G PRO X share the same protocol but are individually unverified, and the G PRO X 2 is intentionally not supported (it uses a different protocol family).
 
 ## Installation
 

--- a/contents/bin/read_hid_devices
+++ b/contents/bin/read_hid_devices
@@ -45,26 +45,21 @@ class DeviceType(Enum):
     HEADPHONES  = "audio-headphones"
     HEADSET     = "audio-headset"
 
-# A helper class; the same device may show under different pids/ifaces hence this exists to mitigate multiple nearly identical device entries
 class DeviceVariant(NamedTuple):
-    pid:    int         # Product ID
-    iface:  int | None  # Interface
+    pid:         int         # Product ID
+    iface:       int | None  # Interface
+    usage_page:  int | None = None  # Report-descriptor usage page of the battery node
 
-# A helper class; holds where a specific data byte is stored: report/msg ID + data byte offset
 class DataPos(NamedTuple):
     report_id:  int     # Report/msg ID e.g. 0x43
     data_byte:  int     # Where a specific byte is located (offset); byte 0 is always report ID
 
-# Points to a location from where a connection state is read out
-# states holds a dict of possible states in which device can be, if not present defaults to charging = false
-# Use case: devices that does not have a charging true/false byte, in other words whether the device is being charged has to be derived from its connection state
+# Charging derived from a connection-state ID byte; missing ID = not charging
 class ChargingStates(NamedTuple):
     pos:    DataPos         # Location of state ID byte
     states: dict[int, bool] # ID -> charging True/False; missing ID defaults to False
 
-# Power read source
-# InputStream is being sent via a msg every few seconds (~3.5 for SC2)
-# This power scheme supports only devices which periodically send its battery state -> Steam Controller, DualShock etc.
+# Passive: device periodically sends its battery report (e.g. SC2)
 class InputStreamSchema(NamedTuple):
     charge:       DataPos                         # Where to look for battery charge
     charge_range: tuple[int, int] | None          # Battery charge min, max; None = battery is already reported in %
@@ -148,55 +143,65 @@ def _voltage_percentage(voltage_mv, curve):
 # ══════════════════════════════════════════════════════════════════════════
 # devices - the registry of known/supported devices (pure data)
 # ══════════════════════════════════════════════════════════════════════════
-# Main class
-# Represents a device, and holds all the important data used for reading it out
 class Device(NamedTuple):
     name:           str                                  # Device name e.g. "Steam Controller"
     device_type:    DeviceType                           # "gamepad", "mouse" etc. see DeviceUtils.js for all supported types
     vid:            int                                  # Vendor ID
     variants:       tuple[DeviceVariant, ...]            # VID, PID, iface used by device - used as path for where to look up device data
     source:         InputStreamSchema | RequestSchema    # How power is read
-    parse:          Callable | None                      # Custom parser: parse(buffers) -> {"percentage", "charging"} | None; None = generic interpret()
+    parse:          Callable | None                      # Custom parser: parse(buffers) -> {"percentage", "charging"} | None | KEEP_READING (not a battery frame, keep waiting); None = generic interpret()
 
-# List of known/supported devices
 # iface = None means that any interface contains battery data
 
 
-# ── Logitech HID++ 1.0 headsets ────────────────────────────────────────────
-# One shared protocol (headsetcontrol's requestBatteryHIDPP): write a 20-byte
-# long message, read a 7-byte short reply on report 0x10 that echoes the
-# request's 0xff byte. Only the feature command + mV->% curve differ per model.
-# Commands, PIDs, curves and the vendor interface 3 are taken from
-# headsetcontrol (GPL-3.0): logitech_g533.hpp, logitech_g535.hpp,
-# logitech_gpro.hpp, logitech_g633_g933_935.hpp + protocols/logitech_calibrations.hpp.
+# ── Logitech headset battery voltage protocol ───────────────────────────────
+# Logitech headsets report a raw battery voltage over HID++: write a 20-byte
+# long message, read a 7-byte short reply on report 0x10 (byte 1 echoes the
+# request's 0xff device byte); only the feature command + mV->% curve differ.
+# Commands, PIDs and curves from headsetcontrol (GPL-3.0): logitech_g533.hpp,
+# logitech_g535.hpp, logitech_gpro.hpp, logitech_g633_g933_935.hpp +
+# protocols/logitech_calibrations.hpp. Battery node = report-descriptor usage
+# page 0xff43 (G535: consumer page 0x0c, so it pins interface 3).
+# Status: G733 0x0AB5/0x0AFE, G533, G535, G933, G935 and G PRO X confirmed by
+# real Solaar captures; G733 v3 0x0B1F, G PRO 0x0AA7 and G PRO X v0 0x0AAA are
+# protocol-shared, individually unverified. G PRO X 2 excluded: Solaar lists
+# it as 0x0AF7 on the "Centurion transport", a different protocol family.
 G633_CURVE = ((100, 4100), (80, 3950), (60, 3850), (40, 3750), (20, 3650), (10, 3500), (5, 3300), (0, 3150))
 G533_CURVE = ((100, 4200), (50, 3850), (30, 3790), (20, 3750), (5, 3680), (0, 3330))
 G535_CURVE = ((100, 4175), (50, 3817), (30, 3766), (20, 3730), (5, 3664), (0, 3310))
 GPRO_CURVE = ((100, 4150), (50, 3830), (30, 3780), (20, 3740), (5, 3670), (0, 3320))
 
+# parse() result: plausible-looking but not a valid battery frame (e.g. an
+# unrelated report on the same interface) - discard and keep waiting.
+KEEP_READING = object()
+
 
 def _logitech_voltage_parse(curve):
-    # 0x10 reply: [0]=0x10, [1]=0xff, [2]=status (0xff = off), [3]=0x00,
-    # [4..5]=voltage big-endian, [6]=charge state (0x01 discharging, 0x03 charging)
+    # 0x10 reply: [0]=0x10, [1]=0xff (echo of the request's device byte),
+    # [2]=status (0xff = device off), [3]=reserved, [4..5]=voltage big-endian,
+    # [6]=charge state (0x01 discharging, 0x03 charging) - same semantics as
+    # the flags byte of the G733's HID++ ADC battery feature in Solaar captures.
     def parse(buffers):
         buf = buffers[0x10]
         if buf[2] == 0xFF:
-            return None  # device off / not sending
+            return None  # device off / not sending - definitive answer
         voltage_mv = (buf[4] << 8) | buf[5]
         if voltage_mv < curve[-1][1]:
-            return None  # below the lowest calibrated voltage (offline/invalid)
+            return KEEP_READING  # below the lowest calibrated voltage: not the battery frame
+        if voltage_mv > 4600:
+            return KEEP_READING  # implausibly high for a single-cell Li-ion: not the battery frame
         return {"percentage": _voltage_percentage(voltage_mv, curve),
                 "charging": buf[6] == 0x03}
     return parse
 
 
-def _logitech_headset(name, cmd, curve, *pids):
-    """A single HID++ 1.0 headset; returns the ready-made Device."""
+def _logitech_headset(name, cmd, curve, *pids, usage_page=0xFF43, iface=None):
+    """A single Logitech headset; returns the ready-made Device."""
     return Device(
         name=name,
         device_type=DeviceType.HEADSET,
         vid=0x046D,
-        variants=tuple(DeviceVariant(pid, 3) for pid in pids),
+        variants=tuple(DeviceVariant(pid, iface, usage_page) for pid in pids),
         source=RequestSchema(
             charge=DataPos(0x10, 4),
             charge_range=None,
@@ -227,11 +232,7 @@ KNOWN_DEVICES = [
             request  = bytes.fromhex('b306') + b'\x00' * 62,
             timeout  = REQUEST_TIMEOUT_SEC,
         ),
-        # Keychron M5: byte 20 of the 0xB4 reply is the level (0-100) when
-        # discharging and "128 + level" while charging (the 0x80 flag bit is
-        # set), so charging level = raw - 128; the 0x87/0x89 bytes seen on real
-        # devices decode to 7%/9%, consistent with the 6% discharge observed
-        # just before.
+        # byte 20 = level 0-100 discharging, "128 + level" while charging (0x80 flag)
         parse=lambda buffers: (
             {"percentage": max(0, min(buffers[0xB4][20] - 128, 100)), "charging": True}
             if buffers[0xB4][20] > 100
@@ -263,14 +264,16 @@ KNOWN_DEVICES = [
         ),
         parse=None,
     ),
-    # ── Logitech HID++ 1.0 headsets ────────────────────────────────────────
-    _logitech_headset("Logitech G633/G635/G733/G933/G935", (0x08, 0x0A), G633_CURVE, 0x0A5C, 0x0A89, 0x0A5B, 0x0A87, 0x0AB5, 0x0AFE, 0x0B1F),
+    # ── Logitech headsets ──────────────────────────────────────────────────
+    _logitech_headset("Logitech G733/G933/G935", (0x08, 0x0A), G633_CURVE, 0x0A5B, 0x0A87, 0x0AB5, 0x0AFE, 0x0B1F),
     _logitech_headset("Logitech G533", (0x07, 0x01), G533_CURVE, 0x0A66),
-    _logitech_headset("Logitech G535", (0x05, 0x0D), G535_CURVE, 0x0AC4),
-    _logitech_headset("Logitech G PRO Series", (0x06, 0x0D), GPRO_CURVE, 0x0AA7, 0x0AAA, 0x0ABA, 0x0AFB, 0x0AFC),
+    _logitech_headset("Logitech G535", (0x05, 0x0D), G535_CURVE, 0x0AC4, usage_page=None, iface=3),
+    _logitech_headset("Logitech G PRO Series", (0x06, 0x0D), GPRO_CURVE, 0x0AA7, 0x0AAA, 0x0ABA),
 ]
 
-# Ptr to a location/device that has been found
+# PIDs whose variants select the battery node by report-descriptor usage page
+_USAGE_PAGE_PIDS = {variant.pid for dev in KNOWN_DEVICES for variant in dev.variants if variant.usage_page is not None}
+
 class FoundDevice(NamedTuple):
     devpath: str
     serial:  str
@@ -305,7 +308,6 @@ def parse_uevent(path):
         vid = int(m.group(1), 16)
         pid = int(m.group(2), 16)
 
-    # HID_PHYS holds the physical device path plus its interface: ".../input4"
     iface = -1
     phys = fields.get("HID_PHYS", "")
     m = _HID_PHYS_RE.match(phys)
@@ -317,13 +319,57 @@ def parse_uevent(path):
 
     return vid, pid, iface, serial, phys
 
+# Walks a raw HID report descriptor for its usage pages. Item byte: bits 0-1
+# size (0/1/2/4), bits 2-3 type, bits 4-7 tag. Usage Page = Global/tag 0,
+# Usage = Local/tag 0; 1-byte usages inherit the current page, 2-byte usages
+# carry their own in the high byte.
+def _parse_usage_pages(data):
+    pages = set()
+    page = 0
+    i = 0
+    n = len(data)
+    while i < n:
+        b = data[i]
+        i += 1
+        if b == 0xFE:  # long item: skip its length byte + payload
+            length = data[i] if i < n else 0
+            i += 1 + length
+            continue
+        item_len = (0, 1, 2, 4)[b & 0x03]
+        if i + item_len > n:
+            break
+        value = data[i:i + item_len]
+        i += item_len
+        btype = (b >> 2) & 0x03
+        btag = (b >> 4) & 0x0F
+        if btype == 1 and btag == 0:  # Global / Usage Page
+            page = int.from_bytes(value, "little")
+            pages.add(page)
+        elif btype == 2 and btag == 0:  # Local / Usage
+            usage = int.from_bytes(value, "little")
+            pages.add(page if item_len < 2 else usage >> 8)
+    return pages
+
+# Usage pages declared by the hidraw node's report descriptor; empty on failure
+def hid_usage_pages(path):
+    try:
+        with open(path, "rb") as f:
+            return _parse_usage_pages(f.read())
+    except OSError:
+        return set()
+
 # Returns the matching Device for a given vid/pid/iface, or None
-def match_device(vid, pid, iface):
+def match_device(vid, pid, iface, usage_pages=None):
     for dev in KNOWN_DEVICES:
         if vid != dev.vid:
             continue
         for variant in dev.variants:
             if pid != variant.pid:
+                continue
+            # usage_page variants select the node by its report-descriptor page
+            if variant.usage_page is not None:
+                if usage_pages and variant.usage_page in usage_pages:
+                    return dev
                 continue
             # iface = None in a variant means any interface contains batt data
             if variant.iface is not None and iface != variant.iface:
@@ -335,19 +381,9 @@ def match_device(vid, pid, iface):
 # ══════════════════════════════════════════════════════════════════════════
 # udev - udev rule files/commands for blocked devices
 # ══════════════════════════════════════════════════════════════════════════
-# A device whose hidraw node can't be opened for the access level its schema
-# needs (missing udev rule) is reported as blocked; this section builds the
-# exact rule file and the exact terminal command the user runs to grant access.
-#
-# Each known device (e.g. "Keychron M5") gets ONE rule file that covers ALL of
-# its connection variants (wireless dongle + wired USB), so granting permission
-# once fixes every way the same device can connect - which interface the battery
-# happens to be on is an implementation detail the user shouldn't care about.
-# The file is wholly ours and can be removed with a plain `rm` (no risk of
-# clobbering user-written rules, no merge bookkeeping). The helper never
-# installs rules itself: it emits the exact terminal command on the blocked
-# device's JSON as "unblock_command", and the user runs it on their own terms
-# (no pkexec involved).
+# A node that can't be opened for the access its schema needs (missing udev
+# rule) is reported as blocked, with the exact command to grant access. One rule
+# file per device covers all its variants; the helper never installs rules.
 UDEV_HEADER = '# Generated by the BatteryWatch widget. Do not edit manually; use the "Copy command" button.'
 
 # Where generated rule files are written; tests redirect this to a sandbox dir.
@@ -384,11 +420,7 @@ def udev_rule_for(vid):
 def _rule_exists(vid):
     return os.path.exists(udev_rule_path(vid))
 
-# The exact shell command a user can paste to authorize this one device. The
-# heredoc is wrapped in `sudo sh -c '...'`: fish rejects `<<EOF` redirections in
-# its own command line, but it treats this as a single quoted argument, so the
-# same readable heredoc pastes cleanly in sh, bash, zsh and fish. The rule body
-# holds no shell metacharacters ($, backticks), so the unquoted delimiter is safe.
+# Wrapped in `sudo sh -c '...'` so the heredoc pastes in sh/bash/zsh/fish
 def udev_unblock_command(vid):
     path = udev_rule_path(vid)
     body = "\n".join([UDEV_HEADER] + udev_rule_for(vid).split("\n"))
@@ -419,7 +451,8 @@ def find_devices():
             continue
         vid, pid, iface, serial, phys = parsed
 
-        desc = match_device(vid, pid, iface)
+        usage_pages = hid_usage_pages(f"/sys/class/hidraw/{name}/device/report_descriptor") if pid in _USAGE_PAGE_PIDS else set()
+        desc = match_device(vid, pid, iface, usage_pages)
         if desc is None:
             continue
 
@@ -518,18 +551,19 @@ def read_status_hw(dev):
                 continue
 
             buffers[report_id] = buf
-            # interpret every report of a schema
             # parse(), if set, sees only such report, so every byte needs to be declared via charge/status positions
             if all(r in buffers for r in needed):
                 if dev.desc.parse is not None:
-                    return dev.desc.parse(buffers)
+                    result = dev.desc.parse(buffers)
+                    if result is KEEP_READING:
+                        buffers.pop(report_id, None)  # not the battery frame; keep waiting for a better one
+                        continue
+                    return result
                 return interpret(schema, buffers)
     finally:
         os.close(fd)
 
-# Stateless per run: reports only a CURRENT reading. A device that doesn't
-# answer simply isn't emitted, so the widget drops it on the next poll - same
-# behaviour as the upower-based providers. No state is kept between runs.
+# Stateless: reports a current reading or nothing; no state between runs.
 def read_status(dev):
     return read_status_hw(dev)
 
@@ -567,9 +601,7 @@ def _device_entry(dev):
                 "percentage": status["percentage"], "charging": status["charging"],
                 "deviceType": dev.desc.device_type.value}
     if is_blocked(dev):
-        # Present but no permission to open: report it so the widget can offer
-        # to copy the udev command for this one device.
-        # "unblock_command" is the exact terminal command for this one device.
+        # Present but no permission to open: offer the exact command to authorize it
         return {"name": dev.desc.name, "serial": dev.serial, "blocked": True,
                 "vid": f"{dev.desc.vid:04x}", "pid": f"{dev.pid:04x}",
                 "unblock_command": udev_unblock_command(dev.desc.vid),

--- a/contents/bin/read_hid_devices
+++ b/contents/bin/read_hid_devices
@@ -131,6 +131,20 @@ def interpret(schema, buffers):
     return {"percentage": percentage, "charging": charging}
 
 
+# Voltage (mV) -> percentage, linear interpolation over a sorted-by-percentage
+# curve of (percent, millivolt) breakpoints (descending mV). Used by the
+# Logitech HID++ headset family, which reports only a raw battery voltage.
+def _voltage_percentage(voltage_mv, curve):
+    for (hi_pct, hi_mv), (lo_pct, lo_mv) in zip(curve, curve[1:]):
+        if voltage_mv >= hi_mv:
+            return hi_pct
+        if voltage_mv >= lo_mv:
+            span = hi_mv - lo_mv
+            fraction = (voltage_mv - lo_mv) / span if span > 0 else 0
+            return round(lo_pct + (hi_pct - lo_pct) * fraction)
+    return curve[-1][0]
+
+
 # ══════════════════════════════════════════════════════════════════════════
 # devices - the registry of known/supported devices (pure data)
 # ══════════════════════════════════════════════════════════════════════════
@@ -146,6 +160,54 @@ class Device(NamedTuple):
 
 # List of known/supported devices
 # iface = None means that any interface contains battery data
+
+
+# ── Logitech HID++ 1.0 headsets ────────────────────────────────────────────
+# One shared protocol (headsetcontrol's requestBatteryHIDPP): write a 20-byte
+# long message, read a 7-byte short reply on report 0x10 that echoes the
+# request's 0xff byte. Only the feature command + mV->% curve differ per model.
+# Commands, PIDs, curves and the vendor interface 3 are taken from
+# headsetcontrol (GPL-3.0): logitech_g533.hpp, logitech_g535.hpp,
+# logitech_gpro.hpp, logitech_g633_g933_935.hpp + protocols/logitech_calibrations.hpp.
+G633_CURVE = ((100, 4100), (80, 3950), (60, 3850), (40, 3750), (20, 3650), (10, 3500), (5, 3300), (0, 3150))
+G533_CURVE = ((100, 4200), (50, 3850), (30, 3790), (20, 3750), (5, 3680), (0, 3330))
+G535_CURVE = ((100, 4175), (50, 3817), (30, 3766), (20, 3730), (5, 3664), (0, 3310))
+GPRO_CURVE = ((100, 4150), (50, 3830), (30, 3780), (20, 3740), (5, 3670), (0, 3320))
+
+
+def _logitech_voltage_parse(curve):
+    # 0x10 reply: [0]=0x10, [1]=0xff, [2]=status (0xff = off), [3]=0x00,
+    # [4..5]=voltage big-endian, [6]=charge state (0x01 discharging, 0x03 charging)
+    def parse(buffers):
+        buf = buffers[0x10]
+        if buf[2] == 0xFF:
+            return None  # device off / not sending
+        voltage_mv = (buf[4] << 8) | buf[5]
+        if voltage_mv < curve[-1][1]:
+            return None  # below the lowest calibrated voltage (offline/invalid)
+        return {"percentage": _voltage_percentage(voltage_mv, curve),
+                "charging": buf[6] == 0x03}
+    return parse
+
+
+def _logitech_headset(name, cmd, curve, *pids):
+    """A single HID++ 1.0 headset; returns the ready-made Device."""
+    return Device(
+        name=name,
+        device_type=DeviceType.HEADSET,
+        vid=0x046D,
+        variants=tuple(DeviceVariant(pid, 3) for pid in pids),
+        source=RequestSchema(
+            charge=DataPos(0x10, 4),
+            charge_range=None,
+            status=ChargingStates(pos=DataPos(0x10, 6), states={0x01: False, 0x03: True}),
+            request=bytes([0x11, 0xFF, cmd[0], cmd[1]]) + b"\x00" * 16,
+            timeout=REQUEST_TIMEOUT_SEC,
+        ),
+        parse=_logitech_voltage_parse(curve),
+    )
+
+
 KNOWN_DEVICES = [
     Device(
         name="Keychron M5",
@@ -200,7 +262,12 @@ KNOWN_DEVICES = [
             )
         ),
         parse=None,
-    )
+    ),
+    # ── Logitech HID++ 1.0 headsets ────────────────────────────────────────
+    _logitech_headset("Logitech G633/G635/G733/G933/G935", (0x08, 0x0A), G633_CURVE, 0x0A5C, 0x0A89, 0x0A5B, 0x0A87, 0x0AB5, 0x0AFE, 0x0B1F),
+    _logitech_headset("Logitech G533", (0x07, 0x01), G533_CURVE, 0x0A66),
+    _logitech_headset("Logitech G535", (0x05, 0x0D), G535_CURVE, 0x0AC4),
+    _logitech_headset("Logitech G PRO Series", (0x06, 0x0D), GPRO_CURVE, 0x0AA7, 0x0AAA, 0x0ABA, 0x0AFB, 0x0AFC),
 ]
 
 # Ptr to a location/device that has been found
@@ -475,6 +542,7 @@ def read_status(dev):
 _SIMULATE_DEVICES = [
     ("Keychron M5", "sim-keychron-m5", 0x3434, "d028", "mouse", 88, False),
     ("Steam Controller 2", "sim-steam-controller-2", 0x28DE, "1304", "gamepad", 85, True),
+    ("Logitech G733", "sim-g733", 0x046D, "0ab5", "audio-headset", 64, True),
 ]
 
 def _simulate():

--- a/contents/bin/read_hid_devices
+++ b/contents/bin/read_hid_devices
@@ -162,10 +162,12 @@ class Device(NamedTuple):
 # logitech_g535.hpp, logitech_gpro.hpp, logitech_g633_g933_935.hpp +
 # protocols/logitech_calibrations.hpp. Battery node = report-descriptor usage
 # page 0xff43 (G535: consumer page 0x0c, so it pins interface 3).
-# Status: G733 0x0AB5/0x0AFE, G533, G535, G933, G935 and G PRO X confirmed by
-# real Solaar captures; G733 v3 0x0B1F, G PRO 0x0AA7 and G PRO X v0 0x0AAA are
-# protocol-shared, individually unverified. G PRO X 2 excluded: Solaar lists
-# it as 0x0AF7 on the "Centurion transport", a different protocol family.
+# Status (third-party sources only - unfortunately, I don't have the real hardware to
+# verify these myself): G733 0x0AB5/0x0AFE, G533, G535, G933, G935 and
+# G PRO X follow from Solaar captures/device lists; G733 v3 0x0B1F,
+# G PRO 0x0AA7 and G PRO X v0 0x0AAA are protocol-shared extrapolations.
+# G PRO X 2 excluded: Solaar lists it as 0x0AF7 on the "Centurion transport",
+# a different protocol family.
 G633_CURVE = ((100, 4100), (80, 3950), (60, 3850), (40, 3750), (20, 3650), (10, 3500), (5, 3300), (0, 3150))
 G533_CURVE = ((100, 4200), (50, 3850), (30, 3790), (20, 3750), (5, 3680), (0, 3330))
 G535_CURVE = ((100, 4175), (50, 3817), (30, 3766), (20, 3730), (5, 3664), (0, 3310))

--- a/contents/bin/tests/test_read_hid_devices.py
+++ b/contents/bin/tests/test_read_hid_devices.py
@@ -65,7 +65,7 @@ rhd = load_helper()
 # ══════════════════════════════════════════════════════════════════════════
 # Scenario fakes: swap these globals between the M5 and SC2 scenarios
 # ══════════════════════════════════════════════════════════════════════════
-scenario = {"uevents": {}, "fake_devs": {}, "reply_fd": None, "reply_buf": bytearray(64), "writes": [], "reads": []}
+scenario = {"uevents": {}, "fake_devs": {}, "reply_fd": None, "reply_buf": bytearray(64), "reply_queue": [], "writes": [], "reads": [], "descriptors": {}, "descriptor_reads": 0}
 
 def m5_uevent(node, pid="0000D028", name="Keychron Keychron Ultra-Link 8K", iface=4):
     return (f"DRIVER=hid-generic\nHID_ID=0003:00003434:{pid}\n"
@@ -73,7 +73,11 @@ def m5_uevent(node, pid="0000D028", name="Keychron Keychron Ultra-Link 8K", ifac
 
 def fake_open(path, mode="r", *a, **k):
     if path.startswith("/sys/class/hidraw"):
-        return io.StringIO(scenario["uevents"][path.split("/")[4]])
+        node = path.split("/")[4]
+        if path.endswith("report_descriptor"):
+            scenario["descriptor_reads"] += 1
+            return io.BytesIO(scenario["descriptors"].get(node, b""))
+        return io.StringIO(scenario["uevents"][node])
     return builtins.open(path, mode, *a, **k)
 
 def fake_osopen(path, flags):
@@ -90,6 +94,8 @@ def fake_write(fd, data):
 def fake_read(fd, size):
     scenario["reads"].append(fd)
     if fd == scenario["reply_fd"]:
+        if scenario["reply_queue"]:
+            return bytes(scenario["reply_queue"].pop(0))
         return bytes(scenario["reply_buf"])
     return b""
 
@@ -104,7 +110,9 @@ class FakePoller:
     def poll(self, timeout_ms):
         for fd in self.reg:
             if fd == scenario["reply_fd"]:
-                return [(fd, select.POLLIN)]
+                # pending data only: a queued sequence, or the standing reply buffer
+                if scenario["reply_queue"] or scenario["reply_buf"]:
+                    return [(fd, select.POLLIN)]
         return []
 
 def install_m5_scenario(pid="0000D028", name="Keychron Keychron Ultra-Link 8K", with_blocked=False):
@@ -119,7 +127,10 @@ def install_m5_scenario(pid="0000D028", name="Keychron Keychron Ultra-Link 8K", 
     scenario["writes"] = []
     scenario["reads"] = []
     scenario["reply_buf"] = bytearray(64)
+    scenario["reply_queue"] = []
     scenario["reply_fd"] = 306
+    scenario["descriptors"] = {}
+    scenario["descriptor_reads"] = 0
 
 def install_sc2_scenario():
     scenario["uevents"] = {
@@ -132,10 +143,20 @@ def install_sc2_scenario():
     scenario["writes"] = []
     scenario["reads"] = []
     scenario["reply_buf"] = bytearray(16)
+    scenario["reply_queue"] = []
     scenario["reply_fd"] = 207
+    scenario["descriptors"] = {}
+    scenario["descriptor_reads"] = 0
 
-def install_g733_scenario(iface=3):
-    # Logitech HID++ headset: vendor interface 3, request 11 ff 08 0a, 0x10 reply
+def hid_descriptor(usage_page=0xFF43):
+    # minimal HID report descriptor declaring one usage page + a 2-byte usage
+    page_item = bytes([0x05, usage_page]) if usage_page <= 0xFF else bytes([0x06, usage_page & 0xFF, (usage_page >> 8) & 0xFF])
+    return page_item + bytes([0x0A, 0x02, 0x02]) + b"\xC0"
+
+def install_g733_scenario(iface=3, usage_page=0xFF43):
+    # Logitech HID++ headset: battery node on usage page 0xff43 (iface is now
+    # irrelevant to matching - only the report descriptor page decides), request
+    # 11 ff 08 0a, 0x10 reply
     scenario["uevents"] = {
         "hidraw8": ("DRIVER=hid-generic\nHID_ID=0003:0000046D:00000AB5\n"
                     "HID_NAME=Logitech G733 LIGHTSPEED\n"
@@ -146,7 +167,10 @@ def install_g733_scenario(iface=3):
     scenario["writes"] = []
     scenario["reads"] = []
     scenario["reply_buf"] = bytearray(8)
+    scenario["reply_queue"] = []
     scenario["reply_fd"] = 208
+    scenario["descriptors"] = {"hidraw8": hid_descriptor(usage_page)} if usage_page is not None else {}
+    scenario["descriptor_reads"] = 0
 
 def set_m5_reply(byte20=87, report_id=0xB4, cmd=0x06):
     buf = bytearray(64)
@@ -451,7 +475,7 @@ def test_simulate_both_report_after_both_rules():
 
 
 # ══════════════════════════════════════════════════════════════════════════
-# Logitech HID++ 1.0 headset (G733): voltage read
+# Logitech headset (G733): voltage read
 # ══════════════════════════════════════════════════════════════════════════
 def test_voltage_percentage_curve():
     assert rhd._voltage_percentage(4100, rhd.G633_CURVE) == 100
@@ -459,10 +483,24 @@ def test_voltage_percentage_curve():
     assert rhd._voltage_percentage(3150, rhd.G633_CURVE) == 0
     assert rhd._voltage_percentage(3000, rhd.G633_CURVE) == 0    # below curve floor -> clamp to 0
 
+def g733_frame(status=0x01, voltage_mv=4000, state=0x03):
+    buf = bytearray(8)
+    buf[0] = 0x10
+    buf[1] = 0xFF
+    buf[2] = status
+    buf[3] = 0x00
+    buf[4] = (voltage_mv >> 8) & 0xFF
+    buf[5] = voltage_mv & 0xFF
+    buf[6] = state
+    return buf
+
+def set_g733_reply(status=0x01, voltage_mv=4000, state=0x03):
+    scenario["reply_buf"] = g733_frame(status, voltage_mv, state)
+
 def test_logitech_voltage_parse_basic():
     install_g733_scenario()
     set_g733_reply(status=0x01, voltage_mv=4050, state=0x01)
-    assert rhd.find_devices()[0].desc.name == "Logitech G633/G635/G733/G933/G935"
+    assert rhd.find_devices()[0].desc.name == "Logitech G733/G933/G935"
     assert rhd.read_status(rhd.find_devices()[0]) == {"percentage": 93, "charging": False}
 
 def test_logitech_voltage_parse_charging():
@@ -476,25 +514,27 @@ def test_logitech_voltage_parse_off_returns_none():
     assert rhd.read_status(rhd.find_devices()[0]) is None
 
 def test_logitech_voltage_parse_low_voltage_returns_none():
+    # a below-curve voltage is not the battery frame: keep waiting, then time out
     install_g733_scenario()
-    set_g733_reply(status=0x01, voltage_mv=3100, state=0x01)
+    scenario["reply_buf"] = bytearray(0)
+    scenario["reply_queue"] = [g733_frame(status=0x01, voltage_mv=3100, state=0x01)]
     assert rhd.read_status(rhd.find_devices()[0]) is None
 
-def set_g733_reply(status=0x01, voltage_mv=4000, state=0x03):
-    buf = bytearray(8)
-    buf[0] = 0x10
-    buf[1] = 0xFF
-    buf[2] = status
-    buf[3] = 0x00
-    buf[4] = (voltage_mv >> 8) & 0xFF
-    buf[5] = voltage_mv & 0xFF
-    buf[6] = state
-    scenario["reply_buf"] = buf
+def test_logitech_bad_frame_then_good_frame_keeps_reading():
+    # a plausible-looking but wrong frame (implausible voltage) must not be
+    # reported; the helper keeps waiting and returns the real battery reply
+    install_g733_scenario()
+    scenario["reply_buf"] = bytearray(0)
+    scenario["reply_queue"] = [
+        g733_frame(status=0x01, voltage_mv=0xFFFF, state=0x01),   # garbage frame
+        g733_frame(status=0x01, voltage_mv=4050, state=0x01),     # real reply
+    ]
+    assert rhd.read_status(rhd.find_devices()[0]) == {"percentage": 93, "charging": False}
 
 def test_logitech_g733_match_and_udev_rule():
     install_g733_scenario()
     sdev = rhd.find_devices()[0]
-    assert sdev.desc.name == "Logitech G633/G635/G733/G933/G935"
+    assert sdev.desc.name == "Logitech G733/G933/G935"
     assert sdev.pid == 0x0AB5
     assert sdev.desc.source.request == bytes([0x11, 0xFF, 0x08, 0x0A]) + b"\x00" * 16, "20-byte long request"
     rule = rhd.udev_rule_for(sdev.desc.vid)
@@ -509,15 +549,77 @@ def test_logitech_g733_offline_produces_no_entry():
 
 def test_logitech_headset_families():
     headsets = {d.name: d for d in rhd.KNOWN_DEVICES if d.device_type == rhd.DeviceType.HEADSET}
-    assert set(headsets) == {"Logitech G633/G635/G733/G933/G935", "Logitech G533", "Logitech G535", "Logitech G PRO Series"}
+    assert set(headsets) == {"Logitech G733/G933/G935", "Logitech G533", "Logitech G535", "Logitech G PRO Series"}
     for d in headsets.values():
-        assert all(v.iface == 3 for v in d.variants), f"{d.name}: all on vendor interface 3"
+        assert all(v.iface == 3 or v.usage_page == 0xFF43 for v in d.variants), \
+            f"{d.name}: battery node pinned by interface 3 or vendor usage page"
         assert d.source.request == bytes([0x11, 0xFF, d.source.request[2], d.source.request[3]]) + b"\x00" * 16, f"{d.name}: 20-byte long request"
         assert d.parse is not None
-    assert [v.pid for v in headsets["Logitech G633/G635/G733/G933/G935"].variants] == [0x0A5C, 0x0A89, 0x0A5B, 0x0A87, 0x0AB5, 0x0AFE, 0x0B1F]
+    assert [v.pid for v in headsets["Logitech G733/G933/G935"].variants] == [0x0A5B, 0x0A87, 0x0AB5, 0x0AFE, 0x0B1F]
+    # G PRO family drops the X2 (0x0AFB/0x0AFC): Solaar lists the X2 as 0x0AF7
+    # on the separate Centurion transport, a different protocol family
+    assert [v.pid for v in headsets["Logitech G PRO Series"].variants] == [0x0AA7, 0x0AAA, 0x0ABA]
+    assert all(v.usage_page == 0xFF43 for v in headsets["Logitech G PRO Series"].variants)
     assert headsets["Logitech G533"].source.request[:4] == bytes([0x11, 0xFF, 0x07, 0x01])
     assert headsets["Logitech G535"].source.request[:4] == bytes([0x11, 0xFF, 0x05, 0x0D])
+    assert headsets["Logitech G535"].variants[0].iface == 3, "G535: consumer page is generic, pins interface 3"
     assert headsets["Logitech G PRO Series"].source.request[:4] == bytes([0x11, 0xFF, 0x06, 0x0D])
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# Logitech headset: battery-node discovery via report-descriptor usage page
+# ══════════════════════════════════════════════════════════════════════════
+def test_parse_usage_pages_detects_vendor_page():
+    pages = rhd._parse_usage_pages(bytes([0x06, 0x43, 0xFF, 0x0A, 0x02, 0x02]) + b"\xC0")
+    assert 0xFF43 in pages, f"vendor page not detected: {pages!r}"
+
+def test_parse_usage_pages_skips_long_items():
+    # a long item (0xFE) before the usage-page item must be skipped cleanly
+    data = bytes([0xFE, 0x03, 0xAA, 0xBB, 0xCC, 0x06, 0x43, 0xFF])
+    assert 0xFF43 in rhd._parse_usage_pages(data)
+
+def test_parse_usage_pages_tolerates_garbage():
+    assert rhd._parse_usage_pages(b"") == set()
+    assert rhd._parse_usage_pages(b"\xFF\xFF\xFF\xFF") == set()  # truncated items
+
+def test_discovery_matches_battery_node_by_usage_page_not_iface():
+    # the battery node is found by its 0xff43 vendor page even when the kernel
+    # numbers the interface 4 (not the Solaar/headsetcontrol "interface 3")
+    install_g733_scenario(iface=4)
+    devs = rhd.find_devices()
+    assert [d.devpath for d in devs] == ["/dev/hidraw8"], f"found: {[d.devpath for d in devs]!r}"
+
+def test_discovery_rejects_node_without_vendor_page():
+    install_g733_scenario(usage_page=0x000C)  # consumer page only: not the battery node
+    assert rhd.find_devices() == []
+
+def test_discovery_picks_battery_node_among_multiple_interfaces():
+    # the dongle exposes several HID nodes: only the one declaring 0xff43 matches
+    install_g733_scenario(iface=3)
+    scenario["uevents"]["hidraw9"] = (
+        "DRIVER=hid-generic\nHID_ID=0003:0000046D:00000AB5\n"
+        "HID_NAME=Logitech G733 LIGHTSPEED\n"
+        "HID_PHYS=usb-0000:00:14.0-11/input2\nHID_UNIQ=\n")
+    scenario["descriptors"]["hidraw9"] = bytes([0x05, 0x0C]) + b"\xC0"  # consumer page, no 0xff43
+    scenario["fake_devs"]["/dev/hidraw9"] = 209
+    set_g733_reply(status=0x01, voltage_mv=4050, state=0x01)  # battery reply on the battery node
+    devs = rhd.find_devices()
+    assert [d.devpath for d in devs] == ["/dev/hidraw8"], f"found: {[d.devpath for d in devs]!r}"
+    assert rhd.read_status(devs[0]) == {"percentage": 93, "charging": False}
+
+def test_discovery_unreadable_descriptor_matches_nothing():
+    # a node whose descriptor can't be read is skipped, never mis-selected
+    install_g733_scenario(usage_page=None)
+    assert rhd.find_devices() == []
+
+def test_descriptor_read_only_for_usage_page_pids():
+    # the report descriptor is only read for PIDs with a usage_page variant
+    install_m5_scenario()                     # iface-only device
+    rhd.find_devices()
+    assert scenario["descriptor_reads"] == 0, f"M5 must not read descriptors: {scenario['descriptor_reads']}"
+    install_g733_scenario()                   # usage-page device
+    rhd.find_devices()
+    assert scenario["descriptor_reads"] == 1, f"G733 reads exactly one: {scenario['descriptor_reads']}"
 
 
 # ══════════════════════════════════════════════════════════════════════════

--- a/contents/bin/tests/test_read_hid_devices.py
+++ b/contents/bin/tests/test_read_hid_devices.py
@@ -134,6 +134,20 @@ def install_sc2_scenario():
     scenario["reply_buf"] = bytearray(16)
     scenario["reply_fd"] = 207
 
+def install_g733_scenario(iface=3):
+    # Logitech HID++ headset: vendor interface 3, request 11 ff 08 0a, 0x10 reply
+    scenario["uevents"] = {
+        "hidraw8": ("DRIVER=hid-generic\nHID_ID=0003:0000046D:00000AB5\n"
+                    "HID_NAME=Logitech G733 LIGHTSPEED\n"
+                    f"HID_PHYS=usb-0000:00:14.0-11/input{iface}\nHID_UNIQ=\n"),
+    }
+    scenario["fake_devs"] = {"/dev/hidraw8": 208}
+    scenario["deny"] = False
+    scenario["writes"] = []
+    scenario["reads"] = []
+    scenario["reply_buf"] = bytearray(8)
+    scenario["reply_fd"] = 208
+
 def set_m5_reply(byte20=87, report_id=0xB4, cmd=0x06):
     buf = bytearray(64)
     buf[0] = report_id
@@ -407,6 +421,8 @@ def test_simulate_both_blocked_before_any_rule():
              "unblock_command": rhd.udev_unblock_command(0x3434), "deviceType": "mouse"},
             {"name": "Steam Controller 2", "serial": "sim-steam-controller-2", "blocked": True, "vid": "28de", "pid": "1304",
              "unblock_command": rhd.udev_unblock_command(0x28de), "deviceType": "gamepad"},
+            {"name": "Logitech G733", "serial": "sim-g733", "blocked": True, "vid": "046d", "pid": "0ab5",
+             "unblock_command": rhd.udev_unblock_command(0x046d), "deviceType": "audio-headset"},
         ]
 
 def test_simulate_m5_reports_after_its_rule():
@@ -417,6 +433,8 @@ def test_simulate_m5_reports_after_its_rule():
             {"name": "Keychron M5", "serial": "sim-keychron-m5", "percentage": 88, "charging": False, "deviceType": "mouse"},
             {"name": "Steam Controller 2", "serial": "sim-steam-controller-2", "blocked": True, "vid": "28de", "pid": "1304",
              "unblock_command": rhd.udev_unblock_command(0x28de), "deviceType": "gamepad"},
+            {"name": "Logitech G733", "serial": "sim-g733", "blocked": True, "vid": "046d", "pid": "0ab5",
+             "unblock_command": rhd.udev_unblock_command(0x046d), "deviceType": "audio-headset"},
         ]
 
 def test_simulate_both_report_after_both_rules():
@@ -427,7 +445,79 @@ def test_simulate_both_report_after_both_rules():
         assert json.loads(run_main_capture()) == [
             {"name": "Keychron M5", "serial": "sim-keychron-m5", "percentage": 88, "charging": False, "deviceType": "mouse"},
             {"name": "Steam Controller 2", "serial": "sim-steam-controller-2", "percentage": 85, "charging": True, "deviceType": "gamepad"},
+            {"name": "Logitech G733", "serial": "sim-g733", "blocked": True, "vid": "046d", "pid": "0ab5",
+             "unblock_command": rhd.udev_unblock_command(0x046d), "deviceType": "audio-headset"},
         ]
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# Logitech HID++ 1.0 headset (G733): voltage read
+# ══════════════════════════════════════════════════════════════════════════
+def test_voltage_percentage_curve():
+    assert rhd._voltage_percentage(4100, rhd.G633_CURVE) == 100
+    assert rhd._voltage_percentage(4050, rhd.G633_CURVE) == 93   # 80 + 20 * 100/150 between 3950-4100
+    assert rhd._voltage_percentage(3150, rhd.G633_CURVE) == 0
+    assert rhd._voltage_percentage(3000, rhd.G633_CURVE) == 0    # below curve floor -> clamp to 0
+
+def test_logitech_voltage_parse_basic():
+    install_g733_scenario()
+    set_g733_reply(status=0x01, voltage_mv=4050, state=0x01)
+    assert rhd.find_devices()[0].desc.name == "Logitech G633/G635/G733/G933/G935"
+    assert rhd.read_status(rhd.find_devices()[0]) == {"percentage": 93, "charging": False}
+
+def test_logitech_voltage_parse_charging():
+    install_g733_scenario()
+    set_g733_reply(status=0x01, voltage_mv=4100, state=0x03)
+    assert rhd.read_status(rhd.find_devices()[0]) == {"percentage": 100, "charging": True}
+
+def test_logitech_voltage_parse_off_returns_none():
+    install_g733_scenario()
+    set_g733_reply(status=0xFF, voltage_mv=4100, state=0x03)
+    assert rhd.read_status(rhd.find_devices()[0]) is None
+
+def test_logitech_voltage_parse_low_voltage_returns_none():
+    install_g733_scenario()
+    set_g733_reply(status=0x01, voltage_mv=3100, state=0x01)
+    assert rhd.read_status(rhd.find_devices()[0]) is None
+
+def set_g733_reply(status=0x01, voltage_mv=4000, state=0x03):
+    buf = bytearray(8)
+    buf[0] = 0x10
+    buf[1] = 0xFF
+    buf[2] = status
+    buf[3] = 0x00
+    buf[4] = (voltage_mv >> 8) & 0xFF
+    buf[5] = voltage_mv & 0xFF
+    buf[6] = state
+    scenario["reply_buf"] = buf
+
+def test_logitech_g733_match_and_udev_rule():
+    install_g733_scenario()
+    sdev = rhd.find_devices()[0]
+    assert sdev.desc.name == "Logitech G633/G635/G733/G933/G935"
+    assert sdev.pid == 0x0AB5
+    assert sdev.desc.source.request == bytes([0x11, 0xFF, 0x08, 0x0A]) + b"\x00" * 16, "20-byte long request"
+    rule = rhd.udev_rule_for(sdev.desc.vid)
+    assert 'MODE="0660"' in rule, "headset needs write access to answer the request"
+    assert "SYMLINK" not in rule
+
+def test_logitech_g733_offline_produces_no_entry():
+    # when the headset is off, replies are status 0xff and must be skipped
+    install_g733_scenario()
+    set_g733_reply(status=0xFF, voltage_mv=0, state=0x03)
+    assert rhd._device_entry(rhd.find_devices()[0]) is None
+
+def test_logitech_headset_families():
+    headsets = {d.name: d for d in rhd.KNOWN_DEVICES if d.device_type == rhd.DeviceType.HEADSET}
+    assert set(headsets) == {"Logitech G633/G635/G733/G933/G935", "Logitech G533", "Logitech G535", "Logitech G PRO Series"}
+    for d in headsets.values():
+        assert all(v.iface == 3 for v in d.variants), f"{d.name}: all on vendor interface 3"
+        assert d.source.request == bytes([0x11, 0xFF, d.source.request[2], d.source.request[3]]) + b"\x00" * 16, f"{d.name}: 20-byte long request"
+        assert d.parse is not None
+    assert [v.pid for v in headsets["Logitech G633/G635/G733/G933/G935"].variants] == [0x0A5C, 0x0A89, 0x0A5B, 0x0A87, 0x0AB5, 0x0AFE, 0x0B1F]
+    assert headsets["Logitech G533"].source.request[:4] == bytes([0x11, 0xFF, 0x07, 0x01])
+    assert headsets["Logitech G535"].source.request[:4] == bytes([0x11, 0xFF, 0x05, 0x0D])
+    assert headsets["Logitech G PRO Series"].source.request[:4] == bytes([0x11, 0xFF, 0x06, 0x0D])
 
 
 # ══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
…G635/G733/G933/G935)

- Implement a shared HID++ 1.0 request/parse path in `read_hid_devices` with per-model command bytes, PIDs, and voltage-to-percentage calibration curves.
- Use interface 3 for all variants; protocol details are sourced from HeadsetControl (GPL-3.0) with attribution in the helper and README.
- Update the README supported-devices list and add a G733 simulation entry.
- Extend `tests/test_read_hid_devices.py` with curve, parse, discovery, udev-rule, and family-registration tests.